### PR TITLE
Add GitHub Projects extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The npm package is the stable core. Extensions live under `extend/` and move thr
 
 Extensions are not board truth. They may publish, report, intake, or add role guidance, but `state.yaml` remains authoritative.
 
-The first cataloged extension, `github-pr-workflow`, prepares receipt-aligned commit boundaries and GitHub PR handoff text from goal receipts without requiring GitHub credentials or making GitHub authoritative. The catalog also includes local-first review, recovery, planning, documentation, audit, and credential-gated handoff extensions such as `ai-diff-risk-review`, `ci-failure-triage`, `docs-drift-audit`, `test-gap-planner`, `release-readiness`, `dependency-upgrade-planner`, `security-review-brief`, `codebase-onboarding-map`, `slack-standup-digest`, and `linear-ticket-handoff`.
+The first cataloged extension, `github-pr-workflow`, prepares receipt-aligned commit boundaries and GitHub PR handoff text from goal receipts without requiring GitHub credentials or making GitHub authoritative. The catalog also includes GitHub Projects sync plus local-first review, recovery, planning, documentation, audit, and credential-gated handoff extensions such as `github-projects`, `ai-diff-risk-review`, `ci-failure-triage`, `docs-drift-audit`, `test-gap-planner`, `release-readiness`, `dependency-upgrade-planner`, `security-review-brief`, `codebase-onboarding-map`, `slack-standup-digest`, and `linear-ticket-handoff`.
 
 ## Running A Goal
 

--- a/extend/README.md
+++ b/extend/README.md
@@ -9,6 +9,7 @@ Each extension folder should contain the files referenced by `extend/catalog.jso
 ## Extensions
 
 - `github-pr-workflow`: prepares receipt-aligned commit boundaries and GitHub pull request handoff text while keeping `state.yaml` authoritative.
+- `github-projects`: mirrors Goal Maker boards into GitHub Projects with dry-run planning, draft issue upserts, ProjectV2 fields, and a Goal Board view.
 - `codebase-onboarding-map`: creates a concise onboarding map from repo files, commands, conventions, and receipts.
 - `slack-standup-digest`: prepares Slack-ready status digests while keeping live delivery credential-gated.
 - `linear-ticket-handoff`: prepares Linear-ready issue text while keeping live issue creation credential-gated.

--- a/extend/catalog.json
+++ b/extend/catalog.json
@@ -67,6 +67,102 @@
       ]
     },
     {
+      "id": "github-projects",
+      "name": "GitHub Projects",
+      "kind": "integration",
+      "version": "0.1.0",
+      "summary": "Mirror Goal Maker state.yaml tasks into GitHub Projects with dry-run planning, ProjectV2 fields, draft issue upserts, and a Goal Board view.",
+      "description": "A cataloged one-way GitHub Projects sync extension that ports PR #1 into the extension system while keeping state.yaml authoritative and live GitHub writes credential-gated.",
+      "source": "extend/github-projects",
+      "docs": "README.md",
+      "use_when": [
+        "A long-running Goal Maker board needs stakeholder visibility in GitHub Projects.",
+        "The team wants one-way sync from state.yaml into ProjectV2 draft issues.",
+        "The PM needs a safe dry-run plan before using GitHub credentials.",
+        "Goal Maker receipts, verification commands, allowed files, owners, and dependencies should appear in a GitHub board."
+      ],
+      "activation": "publish_handoff",
+      "outputs": [
+        "GitHub Projects dry-run plan",
+        "GitHub ProjectV2 draft issue sync",
+        "Goal Board ProjectV2 view"
+      ],
+      "requires_approval": true,
+      "safe_by_default": false,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "github_projects",
+          "stakeholder_board",
+          "external_visibility"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/state.yaml",
+        "GITHUB_PROJECT_ID",
+        "GITHUB_PROJECT_OWNER",
+        "GITHUB_PROJECT_NUMBER"
+      ],
+      "writes": [
+        "GitHub ProjectV2 draft issues",
+        "GitHub ProjectV2 fields",
+        "GitHub ProjectV2 board view"
+      ],
+      "side_effects": [
+        "Live sync creates or updates GitHub Project draft issues, fields, and views."
+      ],
+      "auth": {
+        "env": [
+          "GITHUB_TOKEN"
+        ]
+      },
+      "supports": {
+        "dry_run": true,
+        "live_github_projects": true,
+        "credentials_required": true,
+        "one_way_sync": true,
+        "alternate_token_env": "GH_TOKEN"
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "github-projects/README.md",
+          "sha256": "2e6529440652629dcf44173828899b8144e089f804c2e53725254d9ba1d58ad1"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "github-projects/extension.yaml",
+          "sha256": "127660de4fce721cd2f55fc71e655fa91c80de14a773901827bb53ab44ed5387"
+        },
+        {
+          "path": "scripts/sync-github-project.mjs",
+          "url": "github-projects/scripts/sync-github-project.mjs",
+          "sha256": "f5bab9d6ea01b42d26ff3b0f3e37e74ee510c18ffc4dd63bf4264bef4ccd030b"
+        },
+        {
+          "path": "scripts/lib/goal-state.mjs",
+          "url": "github-projects/scripts/lib/goal-state.mjs",
+          "sha256": "438e966de8b9a525c5f36b8851450308311ea78ec3dc10ee7bf39d8cacf6b625"
+        },
+        {
+          "path": "scripts/lib/github-projects.mjs",
+          "url": "github-projects/scripts/lib/github-projects.mjs",
+          "sha256": "1e3c48e385c9ce8aacf53a756b01633958a2f9363eb01e076ec0bd80a8f79a72"
+        },
+        {
+          "path": "test/github-projects.test.mjs",
+          "url": "github-projects/test/github-projects.test.mjs",
+          "sha256": "71dfc18bf14d6b0a032ff2c58343ad2cf65d98969239a4bf48bc09116d68b08c"
+        },
+        {
+          "path": "examples/goal-board-sync/state.yaml",
+          "url": "github-projects/examples/goal-board-sync/state.yaml",
+          "sha256": "33ab718d27b839fe7b8f7b94a69b796304845c93f2fdddf97308bb05b9d1732e"
+        }
+      ]
+    },
+    {
       "id": "ai-diff-risk-review",
       "name": "AI diff risk review",
       "kind": "review",

--- a/extend/github-projects/README.md
+++ b/extend/github-projects/README.md
@@ -1,0 +1,95 @@
+# GitHub Projects
+
+Mirror a Goal Maker `state.yaml` board into GitHub Projects without making GitHub the source of truth.
+
+This extension ports the GitHub Projects work from PR #1 into the catalog-based extension system. It keeps the package core dependency-free and optional, while giving teams a practical way to publish a Goal Maker board into a familiar project surface.
+
+## Use When
+
+- A long-running Goal Maker board needs stakeholder visibility in GitHub Projects.
+- A team wants one-way sync from `state.yaml` into ProjectV2 draft issues.
+- The PM needs a dry-run plan before using GitHub credentials.
+- Existing Goal Maker receipts, verification commands, allowed files, owners, and dependencies should be visible in a board layout.
+
+## What It Creates
+
+The live sync ensures a GitHub Project has:
+
+- Draft issues keyed by `Task ID`, so reruns update existing cards instead of duplicating them.
+- Status mapping: `queued -> Todo`, `active -> In Progress`, `blocked -> Blocked`, `done -> Done`.
+- Single-select fields for `Status`, `Priority`, and `Work Type`.
+- Text fields for `Task ID`, `Owner`, `Parent ID`, `Depends On`, `Receipt Summary`, `Verify`, `Allowed Files`, and `Goal Updated`.
+- A `Goal Board` board-layout view with useful visible fields.
+
+## Inputs
+
+- `docs/goals/<slug>/state.yaml`
+- Optional `GITHUB_PROJECT_ID`
+- Optional `GITHUB_PROJECT_OWNER` and `GITHUB_PROJECT_NUMBER`
+- `GITHUB_TOKEN` or `GH_TOKEN` for live sync
+
+## Dry Run
+
+Dry-run mode does not call GitHub:
+
+```bash
+node extend/github-projects/scripts/sync-github-project.mjs \
+  --state docs/goals/<slug>/state.yaml \
+  --dry-run
+```
+
+For structured output:
+
+```bash
+node extend/github-projects/scripts/sync-github-project.mjs \
+  --state docs/goals/<slug>/state.yaml \
+  --dry-run \
+  --json
+```
+
+## Live Sync
+
+Use a ProjectV2 node ID:
+
+```bash
+GITHUB_TOKEN=... node extend/github-projects/scripts/sync-github-project.mjs \
+  --state docs/goals/<slug>/state.yaml \
+  --project-id <project-node-id>
+```
+
+Or use an owner and project number:
+
+```bash
+GITHUB_TOKEN=... node extend/github-projects/scripts/sync-github-project.mjs \
+  --state docs/goals/<slug>/state.yaml \
+  --owner <user-or-org> \
+  --project-number <number>
+```
+
+Environment alternatives:
+
+- `GITHUB_PROJECT_ID`
+- `GITHUB_PROJECT_OWNER`
+- `GITHUB_PROJECT_NUMBER`
+- `GITHUB_TOKEN` or `GH_TOKEN`
+
+## Verification
+
+```bash
+node --test extend/github-projects/test/*.test.mjs
+node extend/github-projects/scripts/sync-github-project.mjs \
+  --state extend/github-projects/examples/goal-board-sync/state.yaml \
+  --dry-run
+node extend/github-projects/scripts/sync-github-project.mjs \
+  --state extend/github-projects/examples/goal-board-sync/state.yaml \
+  --dry-run \
+  --json
+```
+
+## Boundaries
+
+- `state.yaml` remains authoritative.
+- The sync is one-way from Goal Maker to GitHub Projects.
+- Missing GitHub credentials block only live sync, not local dry-run validation.
+- Live sync creates or updates GitHub Project draft issues and fields.
+- Native GitHub issue hierarchy and dependencies are represented as fields because ProjectV2 draft issues do not provide full issue relationship semantics.

--- a/extend/github-projects/examples/goal-board-sync/state.yaml
+++ b/extend/github-projects/examples/goal-board-sync/state.yaml
@@ -1,0 +1,63 @@
+version: 2
+
+goal:
+  title: "Goal board sync MVP"
+  slug: "goal-board-sync-mvp"
+  kind: specific
+  tranche: "Mirror a Goal Maker board into an external Kanban surface."
+  status: active
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+
+active_task: T002
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    priority: P3
+    objective: "Map external board API requirements."
+    inputs:
+      - "Board API docs"
+    constraints:
+      - "Read-only."
+    expected_output:
+      - "Required scopes"
+      - "Field mapping"
+    receipt:
+      result: done
+      summary: "The board sync can read Goal Maker state.yaml and mirror tasks into an external board."
+  - id: T002
+    type: worker
+    assignee: Worker
+    status: active
+    priority: P1
+    objective: "Implement one-way external board sync."
+    parent: T001
+    depends_on:
+      - T001
+    allowed_files:
+      - "extend/github-projects/scripts/**"
+      - "README.md"
+    verify:
+      - "node --test extend/github-projects/test/*.test.mjs"
+      - "node extend/github-projects/scripts/sync-github-project.mjs --state extend/github-projects/examples/goal-board-sync/state.yaml --dry-run"
+    stop_if:
+      - "Board API credentials are unavailable."
+    receipt: null
+  - id: T003
+    type: judge
+    assignee: Judge
+    status: queued
+    priority: P2
+    objective: "Audit whether the board sync MVP is ready to document."
+    parent: T002
+    depends_on:
+      - T002
+    receipt: null

--- a/extend/github-projects/extension.yaml
+++ b/extend/github-projects/extension.yaml
@@ -1,0 +1,37 @@
+id: github-projects
+name: GitHub Projects
+kind: integration
+version: 0.1.0
+source_of_truth: local
+description: Mirror Goal Maker state.yaml tasks into GitHub Projects with dry-run planning, ProjectV2 fields, draft issue upserts, and a Goal Board view.
+use_when:
+  - A long-running Goal Maker board needs stakeholder visibility in GitHub Projects.
+  - The team wants one-way sync from state.yaml into ProjectV2 draft issues.
+  - The PM needs a safe dry-run plan before using GitHub credentials.
+  - Goal Maker receipts, verification commands, allowed files, owners, and dependencies should appear in a GitHub board.
+activation: publish_handoff
+outputs:
+  - GitHub Projects dry-run plan
+  - GitHub ProjectV2 draft issue sync
+  - Goal Board ProjectV2 view
+requires_approval: true
+safe_by_default: false
+reads:
+  - docs/goals/<slug>/state.yaml
+  - GITHUB_PROJECT_ID
+  - GITHUB_PROJECT_OWNER
+  - GITHUB_PROJECT_NUMBER
+writes:
+  - GitHub ProjectV2 draft issues
+  - GitHub ProjectV2 fields
+  - GitHub ProjectV2 board view
+side_effects:
+  - Live sync creates or updates GitHub Project draft issues, fields, and views.
+auth:
+  env:
+    - GITHUB_TOKEN
+supports:
+  dry_run: true
+  live_github_projects: true
+  credentials_required: true
+  one_way_sync: true

--- a/extend/github-projects/scripts/lib/github-projects.mjs
+++ b/extend/github-projects/scripts/lib/github-projects.mjs
@@ -1,0 +1,654 @@
+export const GITHUB_PROJECT_FIELDS = {
+  taskId: "Task ID",
+  status: "Status",
+  priority: "Priority",
+  workType: "Work Type",
+  owner: "Owner",
+  parentId: "Parent ID",
+  dependsOn: "Depends On",
+  receiptSummary: "Receipt Summary",
+  verify: "Verify",
+  allowedFiles: "Allowed Files",
+  updated: "Goal Updated",
+};
+
+const STATUS_OPTIONS = [
+  { name: "Todo", color: "GRAY", description: "Task is waiting." },
+  { name: "In Progress", color: "YELLOW", description: "Task is currently active." },
+  { name: "Blocked", color: "RED", description: "Task is blocked." },
+  { name: "Done", color: "GREEN", description: "Task is complete." },
+];
+
+const TYPE_OPTIONS = [
+  { name: "Discovery", color: "BLUE", description: "Evidence gathering and mapping." },
+  { name: "Decision", color: "PURPLE", description: "Review, decision, or audit." },
+  { name: "Execution", color: "ORANGE", description: "Bounded implementation or recovery." },
+  { name: "Coordination", color: "GREEN", description: "Board, handoff, or PM work." },
+  { name: "Recovery", color: "RED", description: "Unblocking or repairing failed verification." },
+];
+
+const PRIORITY_OPTIONS = [
+  { name: "P0", color: "RED", description: "Urgent blocker or safety-critical work." },
+  { name: "P1", color: "ORANGE", description: "Important current-tranche work." },
+  { name: "P2", color: "YELLOW", description: "Useful but not first-order." },
+  { name: "P3", color: "GRAY", description: "Parking lot or follow-up." },
+];
+
+const TEXT_FIELD_SPECS = [
+  ["taskId", GITHUB_PROJECT_FIELDS.taskId],
+  ["owner", GITHUB_PROJECT_FIELDS.owner],
+  ["parentId", GITHUB_PROJECT_FIELDS.parentId],
+  ["dependsOn", GITHUB_PROJECT_FIELDS.dependsOn],
+  ["receiptSummary", GITHUB_PROJECT_FIELDS.receiptSummary],
+  ["verify", GITHUB_PROJECT_FIELDS.verify],
+  ["allowedFiles", GITHUB_PROJECT_FIELDS.allowedFiles],
+  ["updated", GITHUB_PROJECT_FIELDS.updated],
+];
+
+const SINGLE_SELECT_FIELD_SPECS = [
+  ["status", GITHUB_PROJECT_FIELDS.status, STATUS_OPTIONS],
+  ["priority", GITHUB_PROJECT_FIELDS.priority, PRIORITY_OPTIONS],
+  ["workType", GITHUB_PROJECT_FIELDS.workType, TYPE_OPTIONS],
+];
+
+export class GitHubProjectsError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "GitHubProjectsError";
+  }
+}
+
+export class GitHubProjectsClient {
+  constructor({ token, fetchImpl = globalThis.fetch } = {}) {
+    if (!token) {
+      throw new GitHubProjectsError("Missing GITHUB_TOKEN or GH_TOKEN.");
+    }
+    if (!fetchImpl) {
+      throw new GitHubProjectsError("This Node runtime does not provide fetch.");
+    }
+    this.token = token;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async graphql(query, variables = {}) {
+    const response = await this.fetchImpl("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${this.token}`,
+        "content-type": "application/json",
+        "user-agent": "goal-board-sync",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!response.ok) {
+      throw new GitHubProjectsError(`GitHub GraphQL failed with HTTP ${response.status}.`);
+    }
+
+    const data = await response.json();
+    if (data.errors?.length) {
+      throw new GitHubProjectsError(data.errors.map((error) => error.message).join("; "));
+    }
+    return data.data;
+  }
+
+  async rest(path, { method = "GET", body } = {}) {
+    const response = await this.fetchImpl(`https://api.github.com/${path}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${this.token}`,
+        accept: "application/vnd.github+json",
+        "content-type": "application/json",
+        "user-agent": "goal-board-sync",
+        "x-github-api-version": "2026-03-10",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : {};
+    if (!response.ok) {
+      throw new GitHubProjectsError(data.message || `GitHub REST failed with HTTP ${response.status}.`);
+    }
+    return data;
+  }
+
+  projectById(projectId, cursor = null) {
+    return this.graphql(PROJECT_BY_ID_QUERY, { projectId, cursor });
+  }
+
+  projectByOwnerNumber(owner, number, cursor = null) {
+    return this.graphql(PROJECT_BY_OWNER_NUMBER_QUERY, { owner, number, cursor });
+  }
+
+  createTextField(projectId, name) {
+    return this.graphql(CREATE_FIELD_MUTATION, {
+      input: {
+        projectId,
+        name,
+        dataType: "TEXT",
+      },
+    });
+  }
+
+  createSingleSelectField(projectId, name, options) {
+    return this.graphql(CREATE_FIELD_MUTATION, {
+      input: {
+        projectId,
+        name,
+        dataType: "SINGLE_SELECT",
+        singleSelectOptions: options,
+      },
+    });
+  }
+
+  updateSingleSelectField(fieldId, options) {
+    return this.graphql(UPDATE_FIELD_MUTATION, {
+      input: {
+        fieldId,
+        singleSelectOptions: options,
+      },
+    });
+  }
+
+  addDraftIssue(projectId, title, body) {
+    return this.graphql(ADD_DRAFT_ISSUE_MUTATION, {
+      input: {
+        projectId,
+        title,
+        body,
+      },
+    });
+  }
+
+  updateDraftIssue(draftIssueId, title, body) {
+    return this.graphql(UPDATE_DRAFT_ISSUE_MUTATION, {
+      input: {
+        draftIssueId,
+        title,
+        body,
+      },
+    });
+  }
+
+  updateItemField(projectId, itemId, fieldId, value) {
+    return this.graphql(UPDATE_ITEM_FIELD_MUTATION, {
+      input: {
+        projectId,
+        itemId,
+        fieldId,
+        value,
+      },
+    });
+  }
+}
+
+export async function loadProject({ client, projectId, owner, number }) {
+  const pages = [];
+  let cursor = null;
+  let baseProject = null;
+
+  do {
+    const data = projectId
+      ? await client.projectById(projectId, cursor)
+      : await client.projectByOwnerNumber(owner, number, cursor);
+    const project = projectId
+      ? data.node
+      : data.user?.projectV2 || data.organization?.projectV2;
+
+    if (!project) {
+      throw new GitHubProjectsError("GitHub Project not found. Check project ID or owner/project number.");
+    }
+    if (!project.id) {
+      throw new GitHubProjectsError("The supplied GitHub node is not a ProjectV2.");
+    }
+
+    baseProject ||= project;
+    pages.push(...(project.items?.nodes || []));
+    cursor = project.items?.pageInfo?.hasNextPage ? project.items.pageInfo.endCursor : null;
+  } while (cursor);
+
+  return {
+    ...baseProject,
+    items: {
+      ...baseProject.items,
+      nodes: pages,
+    },
+  };
+}
+
+export async function ensureGoalProjectFields(client, project) {
+  const byName = indexFieldsByName(project.fields?.nodes || []);
+  const fields = {};
+
+  for (const [key, name] of TEXT_FIELD_SPECS) {
+    let field = byName.get(name);
+    if (!field) {
+      const response = await client.createTextField(project.id, name);
+      field = response.createProjectV2Field.projectV2Field;
+      byName.set(name, field);
+    } else if (field.dataType !== "TEXT") {
+      throw new GitHubProjectsError(`Existing project field "${name}" must be a text field.`);
+    }
+    fields[key] = field;
+  }
+
+  for (const [key, name, options] of SINGLE_SELECT_FIELD_SPECS) {
+    let field = byName.get(name);
+    if (!field) {
+      const response = await client.createSingleSelectField(project.id, name, options);
+      field = response.createProjectV2Field.projectV2Field;
+    } else if (field.__typename !== "ProjectV2SingleSelectField" || field.dataType !== "SINGLE_SELECT") {
+      throw new GitHubProjectsError(`Existing project field "${name}" must be a single-select field.`);
+    } else {
+      const missing = missingOptions(field, options);
+      if (missing.length) {
+        const merged = [
+          ...(field.options || []).map((option) => ({
+            name: option.name,
+            color: option.color || "GRAY",
+            description: option.description || option.name,
+          })),
+          ...missing,
+        ];
+        const response = await client.updateSingleSelectField(field.id, merged);
+        field = response.updateProjectV2Field.projectV2Field;
+      }
+    }
+    fields[key] = field;
+  }
+
+  return fields;
+}
+
+export function planGitHubProjectSync(tasks, existingItems) {
+  const byTaskId = indexProjectItemsByTaskId(existingItems);
+  return tasks.map((task) => {
+    const existing = byTaskId.get(task.id);
+    if (!existing) {
+      return {
+        type: "create",
+        taskId: task.id,
+        task,
+      };
+    }
+
+    return {
+      type: "update",
+      taskId: task.id,
+      task,
+      itemId: existing.itemId,
+      draftIssueId: existing.draftIssueId,
+    };
+  });
+}
+
+export async function executeGitHubProjectSync({ client, project, fields, tasks, board }) {
+  const operations = planGitHubProjectSync(tasks, project.items?.nodes || []);
+
+  for (const operation of operations) {
+    const body = buildDraftIssueBody(operation.task, board);
+    let itemId = operation.itemId;
+
+    if (operation.type === "create") {
+      const response = await client.addDraftIssue(project.id, operation.task.title, body);
+      itemId = response.addProjectV2DraftIssue.projectItem.id;
+    } else if (operation.draftIssueId) {
+      await client.updateDraftIssue(operation.draftIssueId, operation.task.title, body);
+    }
+
+    for (const update of buildFieldUpdates(operation.task, fields)) {
+      await client.updateItemField(project.id, itemId, update.fieldId, update.value);
+    }
+  }
+
+  return operations;
+}
+
+export async function ensureGoalBoardView({ client, project, fields }) {
+  const existing = (project.views?.nodes || []).find((view) => view.name === "Goal Board" && view.layout === "BOARD_LAYOUT");
+  if (existing) return existing;
+
+  const owner = project.owner;
+  if (!owner?.login || !project.number) {
+    throw new GitHubProjectsError("Cannot create Goal Board view without project owner and number.");
+  }
+
+  const ownerPath = owner.__typename === "Organization"
+    ? `orgs/${owner.login}`
+    : `users/${owner.login}`;
+  const visibleFields = [
+    fields.priority,
+    fields.status,
+    fields.workType,
+    fields.owner,
+  ]
+    .map((field) => field?.databaseId)
+    .filter(Boolean);
+
+  return client.rest(`${ownerPath}/projectsV2/${project.number}/views`, {
+    method: "POST",
+    body: {
+      name: "Goal Board",
+      layout: "board",
+      visible_fields: visibleFields,
+    },
+  });
+}
+
+export function buildFieldUpdates(task, fields) {
+  return [
+    textUpdate(fields.taskId, task.id),
+    singleSelectUpdate(fields.status, projectStatusForTask(task.status)),
+    singleSelectUpdate(fields.priority, priorityForTask(task)),
+    singleSelectUpdate(fields.workType, workTypeForTask(task.type)),
+    textUpdate(fields.owner, task.assignee),
+    textUpdate(fields.parentId, task.parentId),
+    textUpdate(fields.dependsOn, task.dependsOn.join(", ")),
+    textUpdate(fields.receiptSummary, task.receiptSummary),
+    textUpdate(fields.verify, task.verify.join("\n")),
+    textUpdate(fields.allowedFiles, task.allowedFiles.join("\n")),
+    textUpdate(fields.updated, task.updatedLabel),
+  ].filter(Boolean);
+}
+
+export function buildDraftIssueBody(task, board) {
+  const lines = [
+    `Mirrors ${board.sourcePath}.`,
+    "",
+    "YAML remains the source of truth. Edit the Goal Maker board, then rerun the sync.",
+    "",
+    `Task ID: ${task.id}`,
+    `Status: ${task.status}`,
+    `Priority: ${priorityForTask(task)}`,
+    `Work type: ${workTypeForTask(task.type)}`,
+    `Owner: ${task.assignee || "unassigned"}`,
+    "",
+    "Objective:",
+    task.objective || "None",
+  ];
+
+  if (task.parentId) {
+    lines.push("", `Parent: ${task.parentId}`);
+  }
+  if (task.dependsOn.length) {
+    lines.push("", "Depends on:", ...task.dependsOn.map((id) => `- ${id}`));
+  }
+  if (task.receiptSummary) {
+    lines.push("", "Receipt:", task.receiptSummary);
+  }
+  if (task.verify.length) {
+    lines.push("", "Verify:", ...task.verify.map((command) => `- ${command}`));
+  }
+  if (task.allowedFiles.length) {
+    lines.push("", "Allowed files:", ...task.allowedFiles.map((file) => `- ${file}`));
+  }
+
+  return lines.join("\n").slice(0, 65000);
+}
+
+export function dryRunGitHubOperations(board) {
+  return board.tasks.map((task) => ({
+    type: "upsert",
+    taskId: task.id,
+    title: task.title,
+    status: task.status,
+    projectStatus: projectStatusForTask(task.status),
+    priority: priorityForTask(task),
+    typeLabel: workTypeForTask(task.type),
+  }));
+}
+
+export function projectStatusForTask(status) {
+  if (status === "queued") return "Todo";
+  if (status === "active") return "In Progress";
+  if (status === "blocked") return "Blocked";
+  if (status === "done") return "Done";
+  return "Todo";
+}
+
+export function priorityForTask(task) {
+  if (task.priority) return task.priority;
+  if (task.status === "blocked") return "P0";
+  if (task.status === "active") return "P1";
+  if (task.status === "done") return "P3";
+  return "P2";
+}
+
+export function workTypeForTask(type) {
+  if (type === "scout") return "Discovery";
+  if (type === "judge") return "Decision";
+  if (type === "worker") return "Execution";
+  if (type === "pm") return "Coordination";
+  return "Coordination";
+}
+
+function indexFieldsByName(fields) {
+  return new Map((fields || []).filter(Boolean).map((field) => [field.name, field]));
+}
+
+function missingOptions(field, requiredOptions) {
+  const existing = new Set((field.options || []).map((option) => option.name));
+  return requiredOptions.filter((option) => !existing.has(option.name));
+}
+
+function indexProjectItemsByTaskId(items) {
+  const byTaskId = new Map();
+
+  for (const item of items || []) {
+    const taskId = item.taskId?.text?.trim();
+    if (!taskId) continue;
+    const draftIssueId = item.content?.__typename === "DraftIssue" ? item.content.id : null;
+    byTaskId.set(taskId, {
+      itemId: item.id,
+      draftIssueId,
+      item,
+    });
+  }
+
+  return byTaskId;
+}
+
+function textUpdate(field, text) {
+  if (!field?.id) return null;
+  return {
+    fieldId: field.id,
+    value: {
+      text: String(text ?? "").slice(0, 1024),
+    },
+  };
+}
+
+function singleSelectUpdate(field, name) {
+  if (!field?.id) return null;
+  const option = (field.options || []).find((candidate) => candidate.name === name);
+  if (!option) {
+    throw new GitHubProjectsError(`Field "${field.name}" is missing option "${name}".`);
+  }
+  return {
+    fieldId: field.id,
+    value: {
+      singleSelectOptionId: option.id,
+    },
+  };
+}
+
+const PROJECT_FIELDS_FRAGMENT = `
+  id
+  number
+  title
+  url
+  owner {
+    __typename
+    ... on User {
+      login
+    }
+    ... on Organization {
+      login
+    }
+  }
+  fields(first: 100) {
+    nodes {
+      __typename
+      ... on ProjectV2Field {
+        id
+        databaseId
+        name
+        dataType
+      }
+      ... on ProjectV2SingleSelectField {
+        id
+        databaseId
+        name
+        dataType
+        options {
+          id
+          name
+          color
+          description
+        }
+      }
+    }
+  }
+  items(first: 100, after: $cursor) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      id
+      taskId: fieldValueByName(name: "Task ID") {
+        ... on ProjectV2ItemFieldTextValue {
+          text
+        }
+      }
+      content {
+        __typename
+        ... on DraftIssue {
+          id
+          title
+          body
+        }
+      }
+    }
+  }
+  views(first: 50) {
+    nodes {
+      id
+      number
+      name
+      layout
+    }
+  }
+`;
+
+const PROJECT_BY_ID_QUERY = `
+  query GoalBoardProjectById($projectId: ID!, $cursor: String) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        ${PROJECT_FIELDS_FRAGMENT}
+      }
+    }
+  }
+`;
+
+const PROJECT_BY_OWNER_NUMBER_QUERY = `
+  query GoalBoardProjectByOwnerNumber($owner: String!, $number: Int!, $cursor: String) {
+    user(login: $owner) {
+      projectV2(number: $number) {
+        ${PROJECT_FIELDS_FRAGMENT}
+      }
+    }
+    organization(login: $owner) {
+      projectV2(number: $number) {
+        ${PROJECT_FIELDS_FRAGMENT}
+      }
+    }
+  }
+`;
+
+const CREATE_FIELD_MUTATION = `
+  mutation GoalBoardCreateField($input: CreateProjectV2FieldInput!) {
+    createProjectV2Field(input: $input) {
+      projectV2Field {
+        __typename
+        ... on ProjectV2Field {
+          id
+          databaseId
+          name
+          dataType
+        }
+        ... on ProjectV2SingleSelectField {
+          id
+          databaseId
+          name
+          dataType
+          options {
+            id
+            name
+            color
+            description
+          }
+        }
+      }
+    }
+  }
+`;
+
+const UPDATE_FIELD_MUTATION = `
+  mutation GoalBoardUpdateField($input: UpdateProjectV2FieldInput!) {
+    updateProjectV2Field(input: $input) {
+      projectV2Field {
+        __typename
+        ... on ProjectV2SingleSelectField {
+          id
+          databaseId
+          name
+          dataType
+          options {
+            id
+            name
+            color
+            description
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ADD_DRAFT_ISSUE_MUTATION = `
+  mutation GoalBoardAddDraftIssue($input: AddProjectV2DraftIssueInput!) {
+    addProjectV2DraftIssue(input: $input) {
+      projectItem {
+        id
+        content {
+          __typename
+          ... on DraftIssue {
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+
+const UPDATE_DRAFT_ISSUE_MUTATION = `
+  mutation GoalBoardUpdateDraftIssue($input: UpdateProjectV2DraftIssueInput!) {
+    updateProjectV2DraftIssue(input: $input) {
+      draftIssue {
+        id
+      }
+    }
+  }
+`;
+
+const UPDATE_ITEM_FIELD_MUTATION = `
+  mutation GoalBoardUpdateItemField($input: UpdateProjectV2ItemFieldValueInput!) {
+    updateProjectV2ItemFieldValue(input: $input) {
+      projectV2Item {
+        id
+      }
+    }
+  }
+`;

--- a/extend/github-projects/scripts/lib/goal-state.mjs
+++ b/extend/github-projects/scripts/lib/goal-state.mjs
@@ -1,0 +1,332 @@
+import { readFile } from "node:fs/promises";
+
+const VALID_STATUSES = new Set(["queued", "active", "blocked", "done"]);
+const VALID_PRIORITIES = new Set(["P0", "P1", "P2", "P3"]);
+
+export class GoalStateError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "GoalStateError";
+  }
+}
+
+export async function loadGoalBoard(path) {
+  const text = await readFile(path, "utf8");
+  return normalizeGoalBoard(parseGoalStateText(text), path);
+}
+
+export function parseGoalStateText(text) {
+  const lines = tokenizeYaml(text);
+  if (!lines.length) {
+    throw new GoalStateError("Goal state is empty.");
+  }
+
+  const [value, nextIndex] = parseBlock(lines, 0, lines[0].indent);
+  if (nextIndex < lines.length) {
+    throw new GoalStateError(`Could not parse line ${lines[nextIndex].number}.`);
+  }
+  return value;
+}
+
+export function normalizeGoalBoard(document, sourcePath = "<memory>") {
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    throw new GoalStateError("Goal state must be a YAML mapping.");
+  }
+  if (Number(document.version) !== 2) {
+    throw new GoalStateError("Only Goal Maker v2 state.yaml files are supported.");
+  }
+  if (!document.goal || typeof document.goal !== "object") {
+    throw new GoalStateError("Missing goal metadata.");
+  }
+  if (!Array.isArray(document.tasks) || document.tasks.length === 0) {
+    throw new GoalStateError("Missing non-empty tasks list.");
+  }
+
+  const goal = document.goal;
+  const tasks = document.tasks.map((task, index) => normalizeTask(task, index));
+  const activeTasks = tasks.filter((task) => task.status === "active");
+  if (activeTasks.length > 1) {
+    throw new GoalStateError("Goal state has more than one active task.");
+  }
+
+  return {
+    sourcePath,
+    title: cleanText(goal.title || "Untitled goal"),
+    slug: cleanText(goal.slug || "untitled-goal"),
+    kind: cleanText(goal.kind || "open_ended"),
+    tranche: cleanText(goal.tranche || ""),
+    status: cleanText(goal.status || "active"),
+    activeTask: cleanText(document.active_task || activeTasks[0]?.id || ""),
+    tasks,
+  };
+}
+
+function normalizeTask(task, index) {
+  if (!task || typeof task !== "object" || Array.isArray(task)) {
+    throw new GoalStateError(`Task ${index + 1} must be a mapping.`);
+  }
+
+  const id = cleanText(task.id);
+  const status = cleanText(task.status);
+  if (!id) {
+    throw new GoalStateError(`Task ${index + 1} is missing id.`);
+  }
+  if (!VALID_STATUSES.has(status)) {
+    throw new GoalStateError(`Task ${id} has unsupported status "${status}".`);
+  }
+
+  return {
+    id,
+    title: titleForTask(task),
+    objective: cleanText(task.objective || ""),
+    status,
+    priority: normalizePriority(task.priority, status),
+    type: cleanText(task.type || "pm"),
+    assignee: cleanText(task.assignee || ""),
+    receiptSummary: summarizeReceipt(task.receipt),
+    allowedFiles: normalizeStringList(task.allowed_files),
+    verify: normalizeStringList(task.verify),
+    parentId: cleanText(task.parent || task.parent_id || ""),
+    dependsOn: normalizeStringList(task.depends_on || task.blocked_by),
+    updatedLabel: task.receipt ? `receipt:${cleanText(task.receipt.result || "present")}` : "receipt:none",
+  };
+}
+
+function normalizePriority(priority, status) {
+  const normalized = cleanText(priority).toUpperCase();
+  if (normalized) {
+    if (!VALID_PRIORITIES.has(normalized)) {
+      throw new GoalStateError(`Unsupported priority "${priority}". Use P0, P1, P2, or P3.`);
+    }
+    return normalized;
+  }
+  if (status === "blocked") return "P0";
+  if (status === "active") return "P1";
+  if (status === "done") return "P3";
+  return "P2";
+}
+
+function titleForTask(task) {
+  const objective = cleanText(task.objective || "Untitled task");
+  return objective.replace(/\.$/, "");
+}
+
+function summarizeReceipt(receipt) {
+  if (!receipt) return "";
+  if (typeof receipt === "string") return cleanText(receipt);
+  if (Array.isArray(receipt) || typeof receipt !== "object") return cleanText(receipt);
+
+  if (receipt.summary) return cleanText(receipt.summary);
+  if (receipt.decision) return cleanText(receipt.decision);
+  if (receipt.note) return `See ${cleanText(receipt.note)}`;
+  if (receipt.result) return `Result: ${cleanText(receipt.result)}`;
+  return "";
+}
+
+function normalizeStringList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.map(cleanText).filter(Boolean);
+  return [cleanText(value)].filter(Boolean);
+}
+
+function cleanText(value) {
+  return String(value ?? "").trim();
+}
+
+function tokenizeYaml(text) {
+  return text
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((raw, index) => {
+      const withoutComments = stripComment(raw).replace(/\s+$/, "");
+      if (!withoutComments.trim()) return null;
+      const indent = withoutComments.match(/^ */)[0].length;
+      if (indent % 2 !== 0) {
+        throw new GoalStateError(`Unsupported odd indentation at line ${index + 1}.`);
+      }
+      return {
+        number: index + 1,
+        indent,
+        text: withoutComments.trimStart(),
+      };
+    })
+    .filter(Boolean);
+}
+
+function stripComment(line) {
+  let quote = null;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    const previous = line[index - 1];
+    if ((char === "\"" || char === "'") && previous !== "\\") {
+      quote = quote === char ? null : quote || char;
+      continue;
+    }
+    if (char === "#" && !quote && (index === 0 || /\s/.test(previous))) {
+      return line.slice(0, index);
+    }
+  }
+  return line;
+}
+
+function parseBlock(lines, index, indent) {
+  if (index >= lines.length) return [{}, index];
+  if (lines[index].indent < indent) return [{}, index];
+  if (lines[index].text.startsWith("- ")) {
+    return parseArray(lines, index, indent);
+  }
+  return parseObject(lines, index, indent);
+}
+
+function parseObject(lines, index, indent) {
+  const object = {};
+
+  while (index < lines.length) {
+    const line = lines[index];
+    if (line.indent < indent) break;
+    if (line.indent !== indent || line.text.startsWith("- ")) break;
+
+    const { key, valueText } = splitKeyValue(line);
+    index += 1;
+
+    if (valueText === "") {
+      if (index < lines.length && lines[index].indent > indent) {
+        const [child, nextIndex] = parseBlock(lines, index, lines[index].indent);
+        object[key] = child;
+        index = nextIndex;
+      } else {
+        object[key] = {};
+      }
+    } else {
+      object[key] = parseScalar(valueText);
+    }
+  }
+
+  return [object, index];
+}
+
+function parseArray(lines, index, indent) {
+  const array = [];
+
+  while (index < lines.length) {
+    const line = lines[index];
+    if (line.indent !== indent || !line.text.startsWith("- ")) break;
+
+    const content = line.text.slice(2).trim();
+    index += 1;
+
+    if (content === "") {
+      if (index < lines.length && lines[index].indent > indent) {
+        const [child, nextIndex] = parseBlock(lines, index, lines[index].indent);
+        array.push(child);
+        index = nextIndex;
+      } else {
+        array.push(null);
+      }
+      continue;
+    }
+
+    if (isInlineMapping(content)) {
+      const object = {};
+      const { key, valueText } = splitKeyValue({ text: content, number: line.number });
+      if (valueText === "") {
+        if (index < lines.length && lines[index].indent > indent) {
+          const [child, nextIndex] = parseBlock(lines, index, lines[index].indent);
+          object[key] = child;
+          index = nextIndex;
+        } else {
+          object[key] = {};
+        }
+      } else {
+        object[key] = parseScalar(valueText);
+      }
+
+      if (index < lines.length && lines[index].indent > indent) {
+        const [child, nextIndex] = parseBlock(lines, index, lines[index].indent);
+        if (child && typeof child === "object" && !Array.isArray(child)) {
+          Object.assign(object, child);
+        } else {
+          throw new GoalStateError(`Expected mapping below line ${line.number}.`);
+        }
+        index = nextIndex;
+      }
+      array.push(object);
+    } else {
+      array.push(parseScalar(content));
+    }
+  }
+
+  return [array, index];
+}
+
+function splitKeyValue(line) {
+  const separator = line.text.indexOf(":");
+  if (separator <= 0) {
+    throw new GoalStateError(`Expected key/value pair at line ${line.number}.`);
+  }
+  return {
+    key: line.text.slice(0, separator).trim(),
+    valueText: line.text.slice(separator + 1).trim(),
+  };
+}
+
+function isInlineMapping(text) {
+  return /^[A-Za-z0-9_.-]+:\s*/.test(text);
+}
+
+function parseScalar(text) {
+  if (text === "[]") return [];
+  if (text === "{}") return {};
+  if (text === "null" || text === "~") return null;
+  if (text === "true") return true;
+  if (text === "false") return false;
+  if (/^-?\d+(\.\d+)?$/.test(text)) return Number(text);
+  if (text.startsWith("[") && text.endsWith("]")) {
+    const inner = text.slice(1, -1).trim();
+    if (!inner) return [];
+    return splitInlineArray(inner).map(parseScalar);
+  }
+  if (
+    (text.startsWith("\"") && text.endsWith("\"")) ||
+    (text.startsWith("'") && text.endsWith("'"))
+  ) {
+    return unquote(text);
+  }
+  if (text === "|" || text === ">") {
+    throw new GoalStateError("Block scalar YAML is not supported by this lightweight parser.");
+  }
+  return text;
+}
+
+function unquote(text) {
+  if (text.startsWith("'")) {
+    return text.slice(1, -1).replace(/''/g, "'");
+  }
+  return text
+    .slice(1, -1)
+    .replace(/\\"/g, "\"")
+    .replace(/\\n/g, "\n")
+    .replace(/\\\\/g, "\\");
+}
+
+function splitInlineArray(text) {
+  const values = [];
+  let quote = null;
+  let start = 0;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const previous = text[index - 1];
+    if ((char === "\"" || char === "'") && previous !== "\\") {
+      quote = quote === char ? null : quote || char;
+      continue;
+    }
+    if (char === "," && !quote) {
+      values.push(text.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+
+  values.push(text.slice(start).trim());
+  return values;
+}

--- a/extend/github-projects/scripts/sync-github-project.mjs
+++ b/extend/github-projects/scripts/sync-github-project.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import { resolve } from "node:path";
+import { loadGoalBoard } from "./lib/goal-state.mjs";
+import {
+  GITHUB_PROJECT_FIELDS,
+  GitHubProjectsClient,
+  dryRunGitHubOperations,
+  ensureGoalBoardView,
+  ensureGoalProjectFields,
+  executeGitHubProjectSync,
+  loadProject,
+} from "./lib/github-projects.mjs";
+
+main().catch((error) => {
+  console.error(`GitHub project sync failed: ${error.message}`);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printUsage();
+    return;
+  }
+  if (!options.state) {
+    throw new Error("Missing --state docs/goals/<slug>/state.yaml.");
+  }
+
+  const board = await loadGoalBoard(resolve(options.state));
+  board.sourcePath = options.state;
+  board.json = options.json;
+
+  if (options.dryRun) {
+    printDryRun(board);
+    return;
+  }
+
+  const projectRef = resolveProjectRef(options);
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) {
+    throw new Error("Missing GITHUB_TOKEN or GH_TOKEN. Use --dry-run to validate without GitHub credentials.");
+  }
+
+  const client = new GitHubProjectsClient({ token });
+  const project = await loadProject({
+    client,
+    projectId: projectRef.projectId,
+    owner: projectRef.owner,
+    number: projectRef.number,
+  });
+  const fields = await ensureGoalProjectFields(client, project);
+  const boardView = await ensureGoalBoardView({ client, project, fields });
+  const operations = await executeGitHubProjectSync({
+    client,
+    project,
+    fields,
+    tasks: board.tasks,
+    board,
+  });
+
+  const created = operations.filter((operation) => operation.type === "create").length;
+  const updated = operations.filter((operation) => operation.type === "update").length;
+  console.log(`Synced ${board.tasks.length} tasks to GitHub Project "${project.title}": ${created} created, ${updated} updated.`);
+  const boardUrl = boardView.html_url || (project.url && boardView.number ? `${project.url}/views/${boardView.number}` : "");
+  if (boardUrl) {
+    console.log(`Board view: ${boardUrl}`);
+  }
+  if (project.url) {
+    console.log(project.url);
+  }
+}
+
+function parseArgs(args) {
+  const options = {
+    state: "",
+    projectId: process.env.GITHUB_PROJECT_ID || "",
+    owner: process.env.GITHUB_PROJECT_OWNER || "",
+    number: process.env.GITHUB_PROJECT_NUMBER || "",
+    dryRun: false,
+    json: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--state") {
+      options.state = args[index + 1] || "";
+      index += 1;
+    } else if (arg.startsWith("--state=")) {
+      options.state = arg.slice("--state=".length);
+    } else if (arg === "--project-id") {
+      options.projectId = args[index + 1] || "";
+      index += 1;
+    } else if (arg.startsWith("--project-id=")) {
+      options.projectId = arg.slice("--project-id=".length);
+    } else if (arg === "--owner") {
+      options.owner = args[index + 1] || "";
+      index += 1;
+    } else if (arg.startsWith("--owner=")) {
+      options.owner = arg.slice("--owner=".length);
+    } else if (arg === "--project-number") {
+      options.number = args[index + 1] || "";
+      index += 1;
+    } else if (arg.startsWith("--project-number=")) {
+      options.number = arg.slice("--project-number=".length);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function resolveProjectRef(options) {
+  if (options.projectId) {
+    return { projectId: options.projectId };
+  }
+
+  if (!options.owner || !options.number) {
+    throw new Error("Missing GitHub Project target. Set --project-id or --owner plus --project-number.");
+  }
+
+  const number = Number(options.number);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error("--project-number must be a positive integer.");
+  }
+
+  return {
+    owner: options.owner,
+    number,
+  };
+}
+
+function printUsage() {
+  console.log(`Usage:
+  node extend/github-projects/scripts/sync-github-project.mjs --state docs/goals/<slug>/state.yaml --owner <login> --project-number <number>
+  node extend/github-projects/scripts/sync-github-project.mjs --state docs/goals/<slug>/state.yaml --project-id <project-node-id>
+  node extend/github-projects/scripts/sync-github-project.mjs --state docs/goals/<slug>/state.yaml --dry-run
+  node extend/github-projects/scripts/sync-github-project.mjs --state docs/goals/<slug>/state.yaml --dry-run --json
+
+Environment:
+  GITHUB_TOKEN or GH_TOKEN       Required unless --dry-run is used.
+  GITHUB_PROJECT_ID              Optional ProjectV2 node ID.
+  GITHUB_PROJECT_OWNER           Optional user/org login.
+  GITHUB_PROJECT_NUMBER          Optional project number.
+`);
+}
+
+function printDryRun(board) {
+  if (board.json) {
+    console.log(JSON.stringify({
+      dry_run: true,
+      source: board.sourcePath,
+      title: board.title,
+      slug: board.slug,
+      fields: Object.values(GITHUB_PROJECT_FIELDS),
+      view: "Goal Board",
+      status_mapping: {
+        queued: "Todo",
+        active: "In Progress",
+        blocked: "Blocked",
+        done: "Done",
+      },
+      operations: dryRunGitHubOperations(board),
+    }, null, 2));
+    return;
+  }
+
+  console.log(`Dry run for ${board.title} (${board.slug})`);
+  console.log(`Source: ${board.sourcePath}`);
+  console.log("GitHub Project fields that will be ensured: Task ID, Status, Priority, Work Type, Owner, Parent ID, Depends On, Receipt Summary, Verify, Allowed Files, Goal Updated");
+  console.log("GitHub Project view that will be ensured: Goal Board (Board layout)");
+  console.log("Status mapping: queued -> Todo, active -> In Progress, blocked -> Blocked, done -> Done");
+  for (const operation of dryRunGitHubOperations(board)) {
+    console.log(`UPSERT ${operation.taskId} ${operation.status} -> ${operation.projectStatus} ${operation.priority} ${operation.typeLabel} ${operation.title}`);
+  }
+  console.log(`Planned ${board.tasks.length} draft issue upserts. GitHub was not called.`);
+}

--- a/extend/github-projects/test/github-projects.test.mjs
+++ b/extend/github-projects/test/github-projects.test.mjs
@@ -1,0 +1,210 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { GoalStateError, normalizeGoalBoard, parseGoalStateText } from "../scripts/lib/goal-state.mjs";
+import {
+  GITHUB_PROJECT_FIELDS,
+  buildDraftIssueBody,
+  buildFieldUpdates,
+  ensureGoalBoardView,
+  planGitHubProjectSync,
+  priorityForTask,
+  projectStatusForTask,
+  workTypeForTask,
+} from "../scripts/lib/github-projects.mjs";
+
+describe("goal state parsing", () => {
+  it("normalizes a Goal Maker v2 board", async () => {
+    const text = await readFile(resolve("extend/github-projects/examples/goal-board-sync/state.yaml"), "utf8");
+    const board = normalizeGoalBoard(parseGoalStateText(text));
+
+    assert.equal(board.title, "Goal board sync MVP");
+    assert.equal(board.activeTask, "T002");
+    assert.equal(board.tasks.length, 3);
+    assert.equal(board.tasks[0].title, "Map external board API requirements");
+    assert.equal(board.tasks[1].priority, "P1");
+    assert.equal(board.tasks[0].receiptSummary, "The board sync can read Goal Maker state.yaml and mirror tasks into an external board.");
+    assert.equal(board.tasks[1].parentId, "T001");
+    assert.deepEqual(board.tasks[1].dependsOn, ["T001"]);
+    assert.deepEqual(board.tasks[1].verify, [
+      "node --test extend/github-projects/test/*.test.mjs",
+      "node extend/github-projects/scripts/sync-github-project.mjs --state extend/github-projects/examples/goal-board-sync/state.yaml --dry-run",
+    ]);
+  });
+
+  it("rejects malformed task status", () => {
+    const parsed = parseGoalStateText(`
+version: 2
+goal:
+  title: "Bad board"
+  slug: "bad-board"
+tasks:
+  - id: T001
+    status: moving
+    objective: "Bad status"
+`);
+
+    assert.throws(() => normalizeGoalBoard(parsed), GoalStateError);
+  });
+});
+
+describe("GitHub Projects mapping", () => {
+  it("plans GitHub draft issue creates and updates by task id", () => {
+    const tasks = [
+      {
+        id: "T001",
+        title: "T001: Existing",
+        objective: "Existing",
+        status: "done",
+        type: "scout",
+        assignee: "Scout",
+        receiptSummary: "Done",
+        verify: [],
+        allowedFiles: [],
+        updatedLabel: "receipt:done",
+      },
+      {
+        id: "T002",
+        title: "T002: New",
+        objective: "New",
+        status: "queued",
+        type: "worker",
+        assignee: "Worker",
+        receiptSummary: "",
+        verify: [],
+        allowedFiles: [],
+        updatedLabel: "receipt:none",
+      },
+    ];
+
+    const operations = planGitHubProjectSync(tasks, [
+      {
+        id: "PVTI_existing",
+        taskId: { text: "T001" },
+        content: { __typename: "DraftIssue", id: "DI_existing" },
+      },
+    ]);
+
+    assert.equal(operations[0].type, "update");
+    assert.equal(operations[0].itemId, "PVTI_existing");
+    assert.equal(operations[0].draftIssueId, "DI_existing");
+    assert.equal(operations[1].type, "create");
+  });
+
+  it("builds GitHub field updates for text and single-select fields", () => {
+    const fields = {
+      taskId: { id: "F_task" },
+      status: { id: "F_status", name: GITHUB_PROJECT_FIELDS.status, options: [{ id: "O_progress", name: "In Progress" }] },
+      priority: { id: "F_priority", name: GITHUB_PROJECT_FIELDS.priority, options: [{ id: "O_p1", name: "P1" }] },
+      workType: { id: "F_type", name: GITHUB_PROJECT_FIELDS.workType, options: [{ id: "O_execution", name: "Execution" }] },
+      owner: { id: "F_owner" },
+      parentId: { id: "F_parent" },
+      dependsOn: { id: "F_depends" },
+      receiptSummary: { id: "F_receipt" },
+      verify: { id: "F_verify" },
+      allowedFiles: { id: "F_allowed" },
+      updated: { id: "F_updated" },
+    };
+    const task = {
+      id: "T002",
+      status: "active",
+      type: "worker",
+      assignee: "Worker",
+      receiptSummary: "",
+      verify: ["npm test"],
+      allowedFiles: ["scripts/**"],
+      parentId: "T001",
+      dependsOn: ["T001"],
+      updatedLabel: "receipt:none",
+    };
+
+    const updates = buildFieldUpdates(task, fields);
+    assert.equal(updates.length, 11);
+    assert.deepEqual(updates.find((update) => update.fieldId === "F_status").value, {
+      singleSelectOptionId: "O_progress",
+    });
+    assert.deepEqual(updates.find((update) => update.fieldId === "F_task").value, {
+      text: "T002",
+    });
+    assert.deepEqual(updates.find((update) => update.fieldId === "F_parent").value, { text: "T001" });
+    assert.deepEqual(updates.find((update) => update.fieldId === "F_depends").value, { text: "T001" });
+  });
+
+  it("builds a draft issue body that points back to the state file", () => {
+    const body = buildDraftIssueBody(
+      {
+        id: "T002",
+        objective: "Run sync.",
+        status: "active",
+        type: "worker",
+        assignee: "Worker",
+        receiptSummary: "",
+        verify: ["npm test"],
+        allowedFiles: ["scripts/**"],
+        parentId: "T001",
+        dependsOn: ["T001"],
+      },
+      {
+        sourcePath: "extend/github-projects/examples/goal-board-sync/state.yaml",
+      }
+    );
+
+    assert.match(body, /YAML remains the source of truth/);
+    assert.match(body, /Task ID: T002/);
+    assert.match(body, /Parent: T001/);
+    assert.match(body, /Depends on:/);
+    assert.match(body, /extend\/github-projects\/examples\/goal-board-sync\/state\.yaml/);
+  });
+
+  it("creates a GitHub Board view with visible fields when missing", async () => {
+    const restCalls = [];
+    const view = await ensureGoalBoardView({
+      client: {
+        rest: async (path, options) => {
+          restCalls.push({ path, options });
+          return { html_url: "https://github.com/users/example/projects/1/views/2" };
+        },
+      },
+      project: {
+        number: 1,
+        owner: { __typename: "User", login: "example" },
+        views: { nodes: [] },
+      },
+      fields: {
+        taskId: { databaseId: 1 },
+        status: { databaseId: 2 },
+        priority: { databaseId: 3 },
+        workType: { databaseId: 4 },
+        owner: { databaseId: 5 },
+        receiptSummary: { databaseId: 6 },
+        verify: { databaseId: 7 },
+        allowedFiles: { databaseId: 8 },
+        updated: { databaseId: 9 },
+      },
+    });
+
+    assert.equal(view.html_url, "https://github.com/users/example/projects/1/views/2");
+    assert.equal(restCalls[0].path, "users/example/projectsV2/1/views");
+    assert.equal(restCalls[0].options.body.layout, "board");
+    assert.deepEqual(restCalls[0].options.body.visible_fields, [3, 2, 4, 5]);
+  });
+
+  it("maps Goal Maker task statuses to native GitHub board statuses", () => {
+    assert.equal(projectStatusForTask("queued"), "Todo");
+    assert.equal(projectStatusForTask("active"), "In Progress");
+    assert.equal(projectStatusForTask("blocked"), "Blocked");
+    assert.equal(projectStatusForTask("done"), "Done");
+  });
+
+  it("maps Goal Maker task types and priorities to lean PM fields", () => {
+    assert.equal(workTypeForTask("scout"), "Discovery");
+    assert.equal(workTypeForTask("judge"), "Decision");
+    assert.equal(workTypeForTask("worker"), "Execution");
+    assert.equal(priorityForTask({ status: "blocked", type: "worker" }), "P0");
+    assert.equal(priorityForTask({ status: "active", type: "worker" }), "P1");
+    assert.equal(priorityForTask({ status: "queued", type: "scout" }), "P2");
+    assert.equal(priorityForTask({ status: "done", type: "worker" }), "P3");
+    assert.equal(priorityForTask({ status: "queued", type: "scout", priority: "P0" }), "P0");
+  });
+});


### PR DESCRIPTION
## Summary

Ports the original GitHub Projects board sync into the current catalog-based extension system as `github-projects`.

## What changed

- Moves the GitHub Projects sync runtime under `extend/github-projects/` instead of package-level `goal-maker/scripts/`.
- Adds extension docs, manifest, sync script, local parser/mapping libraries, tests, and an example v2 board.
- Adds `extend/catalog.json` metadata with checksum-pinned files so `goal-maker extend github-projects` and dry-run install work through the extension CLI.
- Keeps the npm package core unchanged: no package script, no package-level dependency, no core runtime changes.
- Adds safe dry-run output, including `--json`, without GitHub credentials.
- Keeps live GitHub Projects writes credential-gated and approval-worthy.

## GitHub Projects behavior

- One-way sync from `state.yaml`; Goal Maker remains source of truth.
- Upserts ProjectV2 draft issues keyed by `Task ID`.
- Ensures status, priority, work type, owner, dependency, receipt, verify, allowed-files, and updated fields.
- Ensures a `Goal Board` board-layout ProjectV2 view.

## Verification

```bash
node internal/cli/goal-maker.mjs extend github-projects --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend install github-projects --catalog-url extend/catalog.json --dry-run --json
GITHUB_TOKEN= node internal/cli/goal-maker.mjs extend github-projects --catalog-url extend/catalog.json --json
node --test extend/github-projects/test/*.test.mjs
node extend/github-projects/scripts/sync-github-project.mjs --state extend/github-projects/examples/goal-board-sync/state.yaml --dry-run --json
npm run check
git diff --check
```

Also smoke-tested installing into a temporary `CODEX_HOME` and running the installed extension script from the copied extension folder.
