### PR TITLE
Harden Goal Maker doctor and board checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ $goal-maker
 
 `$goal-maker` creates a local goal charter and task board, then prints the `/goal` command to run next. It does not start `/goal` automatically.
 
+Native Codex `/goal` is still an under-development Codex feature. Before relying on the printed command, confirm your local Codex runtime is logged in and has goals enabled:
+
+```bash
+codex login status
+codex features enable goals
+npx goal-maker doctor --goal-ready
+```
+
 ![A simple hand-drawn diagram showing a vague goal becoming a Goal Maker board with Scout, Judge, Worker, and a receipt.](internal/assets/goal-maker-flow.png)
 
 ## Why It Exists
@@ -116,6 +124,14 @@ Check what is installed:
 ```bash
 npx goal-maker doctor
 ```
+
+Strictly check whether the native Codex `/goal` runtime is ready too:
+
+```bash
+npx goal-maker doctor --goal-ready
+```
+
+`doctor` reports missing or stale bundled agents, Codex login status, and whether the `goals` feature is enabled. `update` refreshes the installed skill and bundled agents.
 
 Discover optional extensions from the GitHub-hosted catalog:
 

--- a/goal-maker/scripts/check-goal-state.mjs
+++ b/goal-maker/scripts/check-goal-state.mjs
@@ -140,11 +140,32 @@ function taskReceipt(task) {
     value: inline || "object",
     raw,
     has: (key) => new RegExp(`^\\s{6}${key}:`, "m").test(raw),
+    list: (key) => receiptList(raw, key),
+    commandStatuses: () => receiptCommandStatuses(raw),
     scalar: (key) => {
       const match = raw.match(new RegExp(`^\\s{6}${key}:\\s*(.*?)\\s*$`, "m"));
       return match ? clean(match[1]) : null;
     },
   };
+}
+
+function receiptList(raw, key) {
+  const lines = raw.split(/\r?\n/);
+  const start = lines.findIndex((line) => new RegExp(`^\\s{6}${key}:\\s*$`).test(line));
+  if (start === -1) return [];
+  const values = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^\s{6}\S/.test(lines[i])) break;
+    const item = lines[i].match(/^\s{8}-\s*(.+?)\s*$/);
+    if (item) values.push(clean(item[1]));
+  }
+  return values.filter((value) => value !== null);
+}
+
+function receiptCommandStatuses(raw) {
+  return [...raw.matchAll(/^\s{10}status:\s*(.*?)\s*$/gm)]
+    .map((match) => clean(match[1]))
+    .filter((value) => value !== null);
 }
 
 function rootEntryErrors() {
@@ -167,6 +188,10 @@ function rootEntryErrors() {
 const version = topScalar("version");
 const goalStatus = nestedScalar("goal", "status");
 const activeTask = topScalar("active_task");
+const installedAgents = ["scout", "worker", "judge"].map((agent) => ({
+  agent,
+  status: nestedScalar("agents", agent),
+}));
 const continuousUntilFullOutcome = nestedScalar("rules", "continuous_until_full_outcome") === true;
 const missingInputOrCredentialsDoNotStopGoal =
   nestedScalar("rules", "missing_input_or_credentials_do_not_stop_goal") === true;
@@ -182,6 +207,16 @@ if (version !== 2) {
     errors.push("legacy v1 goal state detected; Goal Maker v2 requires version: 2 with a task board. Create a new v2 goal or migrate manually.");
   } else {
     errors.push("state.yaml must declare version: 2");
+  }
+}
+
+if (!["active", "blocked", "done"].includes(goalStatus)) {
+  errors.push(`goal.status must be active, blocked, or done; got ${goalStatus || "<missing>"}`);
+}
+
+for (const { agent, status } of installedAgents) {
+  if (status !== "installed") {
+    errors.push(`agents.${agent} must be installed; got ${status || "<missing>"}`);
   }
 }
 
@@ -206,6 +241,15 @@ for (const task of tasks) {
   }
   if (!["Scout", "Judge", "Worker", "PM"].includes(task.assignee)) {
     errors.push(`task ${task.id} assignee must be Scout, Judge, Worker, or PM`);
+  }
+  const expectedAssignee = {
+    scout: "Scout",
+    judge: "Judge",
+    worker: "Worker",
+    pm: "PM",
+  }[task.type];
+  if (expectedAssignee && task.assignee !== expectedAssignee) {
+    errors.push(`task ${task.id} assignee must be ${expectedAssignee} for type ${task.type}`);
   }
   if (!["queued", "active", "blocked", "done"].includes(task.status)) {
     errors.push(`task ${task.id} status must be queued, active, blocked, or done`);
@@ -241,8 +285,15 @@ if (activeTask && !ids.has(activeTask)) errors.push(`active_task points to unkno
 
 for (const task of tasks) {
   const hasReceipt = task.receipt.present && task.receipt.value !== null;
+  const receiptResult = hasReceipt ? task.receipt.scalar("result") : null;
   if (task.status === "done" && !hasReceipt) {
     errors.push(`done task ${task.id} missing receipt`);
+  }
+  if (task.status === "done" && hasReceipt && receiptResult !== "done") {
+    errors.push(`done task ${task.id} receipt must include result: done`);
+  }
+  if (task.status === "blocked" && !hasReceipt) {
+    errors.push(`blocked task ${task.id} missing receipt`);
   }
   if (task.type === "worker" && task.status === "active") {
     if (task.allowedFiles.length === 0) errors.push(`active Worker task ${task.id} must include allowed_files`);
@@ -252,6 +303,21 @@ for (const task of tasks) {
   if (task.type === "worker" && task.status === "done" && hasReceipt) {
     for (const key of ["changed_files", "commands", "summary"]) {
       if (!task.receipt.has(key)) errors.push(`Worker receipt for ${task.id} missing ${key}`);
+    }
+    const changedFiles = task.receipt.list("changed_files");
+    for (const changedFile of changedFiles) {
+      if (!task.allowedFiles.includes(changedFile)) {
+        errors.push(`Worker receipt for ${task.id} changed file outside allowed_files: ${changedFile}`);
+      }
+    }
+    const commandStatuses = task.receipt.commandStatuses();
+    if (task.receipt.has("commands") && commandStatuses.length === 0) {
+      errors.push(`Worker receipt for ${task.id} commands must include status fields`);
+    }
+    for (const status of commandStatuses) {
+      if (status !== "pass") {
+        errors.push(`Worker receipt for ${task.id} has non-passing command status: ${status}`);
+      }
     }
   }
   if (task.type === "scout" && task.status === "done" && hasReceipt) {

--- a/internal/cli/goal-maker.mjs
+++ b/internal/cli/goal-maker.mjs
@@ -10,6 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { basename, dirname, join, normalize, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -106,7 +107,7 @@ Usage:
   goal-maker install [--codex-home <path>] [--force]
   goal-maker update [--codex-home <path>]
   goal-maker agents [--codex-home <path>] [--force]
-  goal-maker doctor [--codex-home <path>]
+  goal-maker doctor [--codex-home <path>] [--goal-ready]
   goal-maker extend [--catalog-url <url-or-path>] [--kind <kind>] [--json]
   goal-maker extend <id> [--catalog-url <url-or-path>] [--json]
   goal-maker extend install <id> [--catalog-url <url-or-path>] [--dry-run] [--force] [--json]
@@ -151,7 +152,7 @@ function installSkill({ force = true } = {}) {
 function installAgents() {
   const source = join(skillSource, "agents");
   const target = join(codexHome(), "agents");
-  const force = hasFlag("--force");
+  const force = hasFlag("--force") || command === "update" || command === "install";
   mkdirSync(target, { recursive: true });
 
   for (const file of readdirSync(source)) {
@@ -179,6 +180,17 @@ function doctor() {
     ? readdirSync(agentsPath).filter((file) => file.startsWith("goal_") && file.endsWith(".toml"))
     : [];
   const missingAgents = requiredAgentFiles.filter((file) => !agents.includes(file));
+  const staleAgents = requiredAgentFiles.filter((file) => {
+    const installedAgent = join(agentsPath, file);
+    const bundledAgent = join(skillSource, "agents", file);
+    if (!existsSync(installedAgent) || !existsSync(bundledAgent)) return false;
+    return sha256(readFileSync(installedAgent)) !== sha256(readFileSync(bundledAgent));
+  });
+  const goalRuntime = codexGoalRuntimeStatus();
+  const warnings = [];
+  if (!goalRuntime.ready) {
+    warnings.push("native Codex /goal runtime is not ready; run `codex login` and `codex features enable goals` before using /goal.");
+  }
 
   console.log(JSON.stringify({
     codex_home: codexHome(),
@@ -186,9 +198,59 @@ function doctor() {
     skill_path: skillPath,
     installed_agents: agents,
     missing_agents: missingAgents,
+    stale_agents: staleAgents,
+    goal_runtime: goalRuntime,
+    warnings,
   }, null, 2));
 
-  process.exit(installed && missingAgents.length === 0 ? 0 : 1);
+  const installOk = installed && missingAgents.length === 0 && staleAgents.length === 0;
+  const goalReadyOk = !hasFlag("--goal-ready") || goalRuntime.ready;
+  process.exit(installOk && goalReadyOk ? 0 : 1);
+}
+
+function codexGoalRuntimeStatus() {
+  const version = runCodex(["--version"]);
+  const login = version.ok ? runCodex(["login", "status"]) : { ok: false, stdout: "", stderr: "codex CLI unavailable" };
+  const features = version.ok ? runCodex(["features", "list"]) : { ok: false, stdout: "", stderr: "codex CLI unavailable" };
+  const goalFeature = parseGoalFeature(features.stdout);
+  const loggedIn = login.ok && !/not logged in/i.test(`${login.stdout}\n${login.stderr}`);
+
+  return {
+    codex_cli_available: version.ok,
+    codex_version: firstLine(version.stdout),
+    logged_in: loggedIn,
+    login_status: firstLine(login.stdout || login.stderr),
+    goals_feature_enabled: goalFeature.enabled,
+    goals_feature_stage: goalFeature.stage,
+    ready: version.ok && loggedIn && goalFeature.enabled,
+  };
+}
+
+function runCodex(args) {
+  const result = spawnSync("codex", args, {
+    encoding: "utf8",
+    env: { ...process.env, CODEX_HOME: codexHome() },
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: result.stdout || "",
+    stderr: result.stderr || result.error?.message || "",
+  };
+}
+
+function parseGoalFeature(output) {
+  const line = output.split(/\r?\n/).find((candidate) => candidate.trim().startsWith("goals"));
+  if (!line) return { enabled: false, stage: "" };
+  const parts = line.trim().split(/\s{2,}/);
+  return {
+    enabled: parts.at(-1) === "true",
+    stage: parts.slice(1, -1).join(" "),
+  };
+}
+
+function firstLine(value) {
+  return (value || "").split(/\r?\n/).find((line) => line.trim())?.trim() || "";
 }
 
 async function extend() {

--- a/internal/test/check-goal-state.test.mjs
+++ b/internal/test/check-goal-state.test.mjs
@@ -156,6 +156,96 @@ checks:
   }
 });
 
+test("rejects invalid goal status and missing installed agents", () => {
+  const root = makeRoot();
+  try {
+    writeState(root, `
+version: 2
+goal:
+  title: "Bad status"
+  slug: "bad-status"
+  kind: open_ended
+  tranche: "truthful board"
+  status: banana
+rules:
+  continuous_until_full_outcome: true
+active_task: T001
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: active
+    objective: "Map the repo."
+    receipt: null
+`);
+    const result = runChecker(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout.errors.join("\n"), /goal\.status must be active, blocked, or done/i);
+    assert.match(result.stdout.errors.join("\n"), /agents\.scout must be installed/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects task type and assignee mismatch", () => {
+  const root = makeRoot();
+  try {
+    writeState(root, validScoutBoard.replace("assignee: Scout", "assignee: Worker"));
+    const result = runChecker(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout.errors.join("\n"), /assignee must be Scout for type scout/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects blocked task without receipt", () => {
+  const root = makeRoot();
+  try {
+    writeState(root, `
+version: 2
+goal:
+  title: "Blocked slice"
+  slug: "blocked-slice"
+  kind: open_ended
+  tranche: "truthful blocking"
+  status: active
+rules:
+  continuous_until_full_outcome: true
+  missing_input_or_credentials_do_not_stop_goal: true
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+active_task: T002
+tasks:
+  - id: T001
+    type: worker
+    assignee: Worker
+    status: blocked
+    objective: "Run the production-only command."
+    allowed_files:
+      - package.json
+    verify:
+      - npm test
+    stop_if:
+      - "Need production access."
+    receipt: null
+  - id: T002
+    type: scout
+    assignee: Scout
+    status: active
+    objective: "Find a safe local workaround."
+    receipt: null
+`);
+    const result = runChecker(root);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout.errors.join("\n"), /blocked task T001 missing receipt/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("rejects legacy v1 state with gate or units schema", () => {
   const root = makeRoot();
   try {
@@ -284,6 +374,79 @@ checks:
     const result = runChecker(root);
     assert.equal(result.status, 0, result.stderr || JSON.stringify(result.stdout));
     assert.equal(result.stdout.ok, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects done Worker receipts with failed commands or files outside scope", () => {
+  const root = makeRoot();
+  try {
+    writeState(root, `
+version: 2
+goal:
+  title: "False green"
+  slug: "false-green"
+  kind: specific
+  tranche: "truthful receipt"
+  status: done
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  continuous_until_full_outcome: true
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+active_task: null
+tasks:
+  - id: T001
+    type: worker
+    assignee: Worker
+    status: done
+    objective: "Update README only."
+    allowed_files:
+      - README.md
+    verify:
+      - npm test
+    stop_if:
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - README.md
+        - package.json
+      commands:
+        - cmd: npm test
+          status: fail
+      summary: "Claimed done despite failed verification and widened scope."
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: done
+    objective: "Audit completion."
+    receipt:
+      result: done
+      decision: complete
+      full_outcome_complete: true
+      summary: "Incorrectly approved."
+checks:
+  dirty_fingerprint: clean
+  last_verification:
+    result: fail
+    task: T001
+    commands:
+      - cmd: npm test
+        status: fail
+`);
+    const result = runChecker(root);
+    assert.equal(result.status, 1);
+    const errors = result.stdout.errors.join("\n");
+    assert.match(errors, /changed file outside allowed_files: package\.json/i);
+    assert.match(errors, /non-passing command status: fail/i);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/internal/test/goal-maker-cli.test.mjs
+++ b/internal/test/goal-maker-cli.test.mjs
@@ -1,6 +1,6 @@
-import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import test from "node:test";
@@ -8,15 +8,37 @@ import assert from "node:assert/strict";
 
 const cli = resolve("internal/cli/goal-maker.mjs");
 
-function runGoalMaker(args) {
+function runGoalMaker(args, options = {}) {
   const result = spawnSync(process.execPath, [cli, ...args], {
     encoding: "utf8",
+    env: options.env || process.env,
   });
   return {
     status: result.status,
     stdout: result.stdout,
     stderr: result.stderr,
   };
+}
+
+function fakeCodexBin(root, { loggedIn = true, goalsEnabled = true } = {}) {
+  const bin = join(root, "bin");
+  mkdirSync(bin, { recursive: true });
+  const script = [
+    "#!/bin/sh",
+    "if [ \"$1\" = \"--version\" ]; then echo \"codex-cli 0.128.0\"; exit 0; fi",
+    "if [ \"$1\" = \"login\" ] && [ \"$2\" = \"status\" ]; then",
+    loggedIn ? "  echo \"Logged in with ChatGPT\"; exit 0" : "  echo \"Not logged in\"; exit 1",
+    "fi",
+    "if [ \"$1\" = \"features\" ] && [ \"$2\" = \"list\" ]; then",
+    `  echo "goals                               under development  ${goalsEnabled ? "true" : "false"}"; exit 0`,
+    "fi",
+    "exit 2",
+    "",
+  ].join("\n");
+  const path = join(bin, "codex");
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+  return bin;
 }
 
 function sha256(text) {
@@ -87,6 +109,57 @@ test("doctor fails when a required bundled agent is missing", () => {
     assert.deepEqual(report.missing_agents, ["goal_worker.toml"]);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("doctor fails when a bundled agent is stale and update refreshes it", () => {
+  const codexHome = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const install = runGoalMaker(["install", "--codex-home", codexHome]);
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    writeFileSync(join(codexHome, "agents", "goal_worker.toml"), "stale\n");
+
+    const staleDoctor = runGoalMaker(["doctor", "--codex-home", codexHome]);
+    assert.equal(staleDoctor.status, 1, staleDoctor.stderr || staleDoctor.stdout);
+    assert.deepEqual(JSON.parse(staleDoctor.stdout).stale_agents, ["goal_worker.toml"]);
+
+    const update = runGoalMaker(["update", "--codex-home", codexHome]);
+    assert.equal(update.status, 0, update.stderr || update.stdout);
+
+    const refreshedDoctor = runGoalMaker(["doctor", "--codex-home", codexHome]);
+    assert.equal(refreshedDoctor.status, 0, refreshedDoctor.stderr || refreshedDoctor.stdout);
+    assert.deepEqual(JSON.parse(refreshedDoctor.stdout).stale_agents, []);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("doctor reports native goal runtime readiness and supports strict goal-ready mode", () => {
+  const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    const fakeBin = fakeCodexBin(root, { loggedIn: false, goalsEnabled: false });
+    const env = {
+      ...process.env,
+      PATH: `${fakeBin}${delimiter}${process.env.PATH}`,
+    };
+
+    const install = runGoalMaker(["install", "--codex-home", codexHome], { env });
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    const doctor = runGoalMaker(["doctor", "--codex-home", codexHome], { env });
+    assert.equal(doctor.status, 0, doctor.stderr || doctor.stdout);
+    const report = JSON.parse(doctor.stdout);
+    assert.equal(report.goal_runtime.codex_cli_available, true);
+    assert.equal(report.goal_runtime.logged_in, false);
+    assert.equal(report.goal_runtime.goals_feature_enabled, false);
+    assert.equal(report.goal_runtime.ready, false);
+
+    const strictDoctor = runGoalMaker(["doctor", "--goal-ready", "--codex-home", codexHome], { env });
+    assert.equal(strictDoctor.status, 1, strictDoctor.stderr || strictDoctor.stdout);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- report native Codex `/goal` readiness in `goal-maker doctor`, including login and goals feature state
- make stale bundled agents fail doctor and refresh agents during install/update
- tighten board validation for invalid goal status, missing installed agents, type/assignee mismatch, blocked receipts, failed Worker commands, and changed files outside allowed scope
- document the under-development `/goal` dependency and `doctor --goal-ready`

## Testing
- npm run check
- git diff --check
- npm pack --dry-run
- npx goal-maker doctor --goal-ready

## Notes
`doctor --goal-ready` fails in this ACP environment because local Codex is not logged in. That is expected and is the exact failure this patch now surfaces.