### PR TITLE
[codex] Add ten Goal Maker extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The npm package is the stable core. Extensions live under `extend/` and move thr
 
 Extensions are not board truth. They may publish, report, intake, or add role guidance, but `state.yaml` remains authoritative.
 
-The first cataloged extension, `github-pr-workflow`, prepares GitHub PR handoff text from goal receipts without requiring GitHub credentials or making GitHub authoritative.
+The first cataloged extension, `github-pr-workflow`, prepares GitHub PR handoff text from goal receipts without requiring GitHub credentials or making GitHub authoritative. The catalog also includes local-first review, recovery, planning, documentation, audit, and credential-gated handoff extensions such as `ai-diff-risk-review`, `ci-failure-triage`, `docs-drift-audit`, `test-gap-planner`, `release-readiness`, `dependency-upgrade-planner`, `security-review-brief`, `codebase-onboarding-map`, `slack-standup-digest`, and `linear-ticket-handoff`.
 
 ## Running A Goal
 

--- a/extend/README.md
+++ b/extend/README.md
@@ -9,6 +9,9 @@ Each extension folder should contain the files referenced by `extend/catalog.jso
 ## Extensions
 
 - `github-pr-workflow`: prepares GitHub pull request handoff text from Goal Maker receipts while keeping `state.yaml` authoritative.
+- `codebase-onboarding-map`: creates a concise onboarding map from repo files, commands, conventions, and receipts.
+- `slack-standup-digest`: prepares Slack-ready status digests while keeping live delivery credential-gated.
+- `linear-ticket-handoff`: prepares Linear-ready issue text while keeping live issue creation credential-gated.
 - `test-gap-planner`: identifies weak test coverage and proposes the smallest useful next tests.
 - `release-readiness`: assembles release scope, verification, docs, packaging, and publish blockers.
 - `dependency-upgrade-planner`: plans dependency upgrades with policy fit, migration risk, verification, and rollback notes.

--- a/extend/README.md
+++ b/extend/README.md
@@ -9,6 +9,10 @@ Each extension folder should contain the files referenced by `extend/catalog.jso
 ## Extensions
 
 - `github-pr-workflow`: prepares GitHub pull request handoff text from Goal Maker receipts while keeping `state.yaml` authoritative.
+- `test-gap-planner`: identifies weak test coverage and proposes the smallest useful next tests.
+- `release-readiness`: assembles release scope, verification, docs, packaging, and publish blockers.
+- `dependency-upgrade-planner`: plans dependency upgrades with policy fit, migration risk, verification, and rollback notes.
+- `security-review-brief`: prepares a focused local security review brief from changed files and receipts.
 - `ai-diff-risk-review`: prepares a local risk review brief for AI-assisted or agent-produced diffs.
 - `ci-failure-triage`: summarizes failed checks, logs, changed files, and receipts into recovery-focused next steps.
 - `docs-drift-audit`: checks changed behavior and documentation surfaces for stale or missing docs before completion or PR handoff.

--- a/extend/README.md
+++ b/extend/README.md
@@ -9,6 +9,9 @@ Each extension folder should contain the files referenced by `extend/catalog.jso
 ## Extensions
 
 - `github-pr-workflow`: prepares GitHub pull request handoff text from Goal Maker receipts while keeping `state.yaml` authoritative.
+- `ai-diff-risk-review`: prepares a local risk review brief for AI-assisted or agent-produced diffs.
+- `ci-failure-triage`: summarizes failed checks, logs, changed files, and receipts into recovery-focused next steps.
+- `docs-drift-audit`: checks changed behavior and documentation surfaces for stale or missing docs before completion or PR handoff.
 
 ## Catalog Rules
 

--- a/extend/ai-diff-risk-review/README.md
+++ b/extend/ai-diff-risk-review/README.md
@@ -1,0 +1,39 @@
+# AI Diff Risk Review
+
+Review an AI-assisted or agent-produced diff before it moves to PR handoff.
+
+This extension is local-first. It helps a Goal Maker run inspect the original request, board receipts, changed files, verification evidence, and known risk areas so the PM can produce a concise review brief for a human reviewer. It does not approve code, post comments, or call an external model by default.
+
+## Use When
+
+- A Worker slice produced code or documentation changes with AI assistance.
+- The team wants a human-review checklist focused on "almost right" code.
+- Verification passed but the PM still needs to identify residual risk before PR handoff.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Relevant receipt notes
+- `git diff --stat`
+- `git diff`
+- Verification command output
+
+## Output
+
+An AI diff risk review brief with:
+
+- Reviewer summary
+- Changed surface map
+- Highest-risk assumptions
+- Verification coverage
+- Missing or weak evidence
+- Suggested reviewer focus areas
+- Blocked follow-up work, if any
+
+## Boundaries
+
+- `state.yaml` remains authoritative.
+- Passing verification is evidence, not approval.
+- No external model, review API, or GitHub comment is called by default.
+- Live PR comments or automated approval require a separate explicitly approved extension.

--- a/extend/ai-diff-risk-review/extension.yaml
+++ b/extend/ai-diff-risk-review/extension.yaml
@@ -1,0 +1,32 @@
+id: ai-diff-risk-review
+name: AI diff risk review
+kind: review
+version: 0.1.0
+source_of_truth: local
+description: Prepare a local risk review brief for AI-assisted or agent-produced diffs before PR handoff.
+use_when:
+  - A Worker slice produced AI-assisted code or documentation changes.
+  - The PM needs to identify residual risk before review or PR handoff.
+  - Verification passed but human reviewers need a focused risk map.
+activation: after_worker
+outputs:
+  - AI diff risk review brief
+requires_approval: false
+safe_by_default: true
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs/goals/<slug>/notes
+  - git diff --stat
+  - git diff
+  - verification output
+writes:
+  - Review brief Markdown
+side_effects:
+  - none by default
+auth:
+  env: []
+supports:
+  dry_run: true
+  live_github: false
+  credentials_required: false

--- a/extend/catalog.json
+++ b/extend/catalog.json
@@ -61,6 +61,199 @@
           "sha256": "641e998bd6453e1a9160b2fdabf3a251bbfd4f9354e62a61b789e15d8e6f147e"
         }
       ]
+    },
+    {
+      "id": "ai-diff-risk-review",
+      "name": "AI diff risk review",
+      "kind": "review",
+      "version": "0.1.0",
+      "summary": "Prepare a local risk review brief for AI-assisted or agent-produced diffs before PR handoff.",
+      "description": "A local-first review workflow for mapping changed files, Goal Maker receipts, verification evidence, and residual risk into a focused human-review brief.",
+      "source": "extend/ai-diff-risk-review",
+      "docs": "README.md",
+      "use_when": [
+        "A Worker slice produced AI-assisted code or documentation changes.",
+        "The PM needs to identify residual risk before review or PR handoff.",
+        "Verification passed but human reviewers need a focused risk map."
+      ],
+      "activation": "after_worker",
+      "outputs": [
+        "AI diff risk review brief"
+      ],
+      "requires_approval": false,
+      "safe_by_default": true,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "code_review",
+          "pull_request"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs/goals/<slug>/notes",
+        "git diff --stat",
+        "git diff",
+        "verification output"
+      ],
+      "writes": [
+        "Review brief Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": []
+      },
+      "supports": {
+        "dry_run": true,
+        "live_github": false,
+        "credentials_required": false
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "ai-diff-risk-review/README.md",
+          "sha256": "1878273f05dbd6f748e322e489fcb6f8a7f68f7d62c6143de91027f94ecb2a96"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "ai-diff-risk-review/extension.yaml",
+          "sha256": "44f7417ae6aae0e8593038c4a1f5393bfa42eaa98385bd9b93c6b35c6ec2a8ef"
+        }
+      ]
+    },
+    {
+      "id": "ci-failure-triage",
+      "name": "CI failure triage",
+      "kind": "recovery",
+      "version": "0.1.0",
+      "summary": "Summarize failing checks, logs, changed files, and receipts into a recovery-focused CI failure triage brief.",
+      "description": "A local-first recovery workflow for turning failed verification or CI output into suspected causes, next commands, blocked external checks, and a recommended board update.",
+      "source": "extend/ci-failure-triage",
+      "docs": "README.md",
+      "use_when": [
+        "A verification command, build, test, lint, or CI check failed.",
+        "The PM needs a recovery task instead of continuing feature work.",
+        "A reviewer needs concise failure context and next diagnostic commands."
+      ],
+      "activation": "blocked_task",
+      "outputs": [
+        "CI failure triage brief"
+      ],
+      "requires_approval": false,
+      "safe_by_default": true,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "ci",
+          "verification",
+          "recovery"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs/goals/<slug>/notes",
+        "failing command output",
+        "local logs",
+        "git diff --stat"
+      ],
+      "writes": [
+        "Failure triage Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": []
+      },
+      "supports": {
+        "dry_run": true,
+        "live_ci": false,
+        "credentials_required": false
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "ci-failure-triage/README.md",
+          "sha256": "58f01fcf202e0b0bf03060c2288f159ac455621d0a4141367868db394c60d25f"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "ci-failure-triage/extension.yaml",
+          "sha256": "55c1b0ce2161647dc56c4ecdbf0be51bd46e6512a8dc3606a8af0d261cb51b67"
+        }
+      ]
+    },
+    {
+      "id": "docs-drift-audit",
+      "name": "Docs drift audit",
+      "kind": "audit",
+      "version": "0.1.0",
+      "summary": "Compare changed behavior, receipts, and documentation surfaces to catch stale docs before completion or PR handoff.",
+      "description": "A local-first audit workflow for checking whether README, docs, examples, and extension manifests still match the changed behavior and receipts.",
+      "source": "extend/docs-drift-audit",
+      "docs": "README.md",
+      "use_when": [
+        "A Worker slice changed user-facing behavior, commands, extension metadata, or examples.",
+        "The PM needs documentation coverage evidence before final audit.",
+        "A PR handoff should explain docs updates or intentional docs non-changes."
+      ],
+      "activation": "final_audit",
+      "outputs": [
+        "Docs drift audit Markdown"
+      ],
+      "requires_approval": false,
+      "safe_by_default": true,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "documentation",
+          "examples",
+          "extensions"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs/goals/<slug>/notes",
+        "README.md",
+        "docs",
+        "examples",
+        "extend",
+        "git diff --stat",
+        "git diff"
+      ],
+      "writes": [
+        "Docs drift audit Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": []
+      },
+      "supports": {
+        "dry_run": true,
+        "credentials_required": false
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "docs-drift-audit/README.md",
+          "sha256": "a435e26524a0ccc368bd2834d8710a2ae9bf085d7049052519aa1a48122dd020"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "docs-drift-audit/extension.yaml",
+          "sha256": "c386535282d0bdb95b4a7f257c1ba60fa607b58425ccb58da4665590f8c620d4"
+        }
+      ]
     }
   ]
 }

--- a/extend/catalog.json
+++ b/extend/catalog.json
@@ -513,6 +513,202 @@
           "sha256": "8c20f1fc34936a7fd1e1a6ec659caf94e25a2dc5a00c1c6785d60de88cf95633"
         }
       ]
+    },
+    {
+      "id": "codebase-onboarding-map",
+      "name": "Codebase onboarding map",
+      "kind": "documentation",
+      "version": "0.1.0",
+      "summary": "Create a concise local onboarding map from repo files, commands, conventions, examples, and Goal Maker receipts.",
+      "description": "A local-first documentation workflow for helping developers and agents understand a repository before implementation or review.",
+      "source": "extend/codebase-onboarding-map",
+      "docs": "README.md",
+      "use_when": [
+        "A developer or agent is starting work in an unfamiliar repo.",
+        "A broad goal needs an evidence-backed repo map before implementation.",
+        "Reviewers need package boundaries, commands, and conventions in one artifact."
+      ],
+      "activation": "before_worker",
+      "outputs": [
+        "Codebase onboarding map Markdown"
+      ],
+      "requires_approval": false,
+      "safe_by_default": true,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "documentation",
+          "onboarding",
+          "repo_map"
+        ]
+      },
+      "reads": [
+        "README.md",
+        "AGENTS.md",
+        "package manifests",
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs",
+        "examples",
+        "tests"
+      ],
+      "writes": [
+        "Codebase onboarding Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": []
+      },
+      "supports": {
+        "dry_run": true,
+        "credentials_required": false
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "codebase-onboarding-map/README.md",
+          "sha256": "b0c458697cb68fc04ab63d31906fdad7b686ce3c7e191958b48b37fb354966bd"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "codebase-onboarding-map/extension.yaml",
+          "sha256": "46fa6b6078082b18afdaab82ab52d2384f6ba5f80acd740cb1bfa78db6231b00"
+        }
+      ]
+    },
+    {
+      "id": "slack-standup-digest",
+      "name": "Slack standup digest",
+      "kind": "integration",
+      "version": "0.1.0",
+      "summary": "Prepare a Slack-ready status digest from Goal Maker receipts while treating live delivery as credential-gated and approval-required.",
+      "description": "A local-first team communication workflow that produces Slack-ready status text and keeps live Slack delivery separate from board truth.",
+      "source": "extend/slack-standup-digest",
+      "docs": "README.md",
+      "use_when": [
+        "A team wants an async Slack-ready update from a long-running goal.",
+        "A blocked task needs owner-visible context.",
+        "The PM needs to share progress without making Slack board truth."
+      ],
+      "activation": "publish_handoff",
+      "outputs": [
+        "Slack-ready standup digest Markdown"
+      ],
+      "requires_approval": true,
+      "safe_by_default": false,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "slack",
+          "team_status",
+          "blocked_task"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs/goals/<slug>/notes",
+        "git status --short",
+        "verification output"
+      ],
+      "writes": [
+        "Slack digest Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": [
+          "SLACK_BOT_TOKEN"
+        ]
+      },
+      "supports": {
+        "dry_run": true,
+        "live_slack": false,
+        "credentials_required": true
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "slack-standup-digest/README.md",
+          "sha256": "23a0e63fa5746835788481681d75b9e6e9701fab43908b9014deadb819abe643"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "slack-standup-digest/extension.yaml",
+          "sha256": "4f05716707820b60c4f4c3f94d0e7367b0edf7058b464f308da084b95d5b9e9a"
+        }
+      ]
+    },
+    {
+      "id": "linear-ticket-handoff",
+      "name": "Linear ticket handoff",
+      "kind": "integration",
+      "version": "0.1.0",
+      "summary": "Prepare Linear-ready issue text from Goal Maker receipts while treating live issue creation as credential-gated and approval-required.",
+      "description": "A local-first ticket handoff workflow that converts receipts, blockers, verification, and acceptance criteria into Linear-ready issue text.",
+      "source": "extend/linear-ticket-handoff",
+      "docs": "README.md",
+      "use_when": [
+        "A goal produces follow-up work that should become an issue.",
+        "A blocked task needs owner or team tracking.",
+        "The PM needs ticket-ready acceptance criteria from receipts and verification."
+      ],
+      "activation": "publish_handoff",
+      "outputs": [
+        "Linear-ready ticket handoff Markdown"
+      ],
+      "requires_approval": true,
+      "safe_by_default": false,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "linear",
+          "issue_tracker",
+          "blocked_task"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs/goals/<slug>/notes",
+        "git status --short",
+        "git diff --stat",
+        "verification output"
+      ],
+      "writes": [
+        "Linear ticket handoff Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": [
+          "LINEAR_API_KEY"
+        ]
+      },
+      "supports": {
+        "dry_run": true,
+        "live_linear": false,
+        "credentials_required": true
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "linear-ticket-handoff/README.md",
+          "sha256": "2abce4632aae6326b6c626706dd03e3a81ac2321d057ec58480fc34243f040b0"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "linear-ticket-handoff/extension.yaml",
+          "sha256": "072d092be9d58c3b9e181eba182e234435e9370318169228796316a1fdc4d3f4"
+        }
+      ]
     }
   ]
 }

--- a/extend/catalog.json
+++ b/extend/catalog.json
@@ -254,6 +254,265 @@
           "sha256": "c386535282d0bdb95b4a7f257c1ba60fa607b58425ccb58da4665590f8c620d4"
         }
       ]
+    },
+    {
+      "id": "test-gap-planner",
+      "name": "Test gap planner",
+      "kind": "planning",
+      "version": "0.1.0",
+      "summary": "Identify weak test coverage and propose the smallest useful next tests from a diff, receipts, and verification output.",
+      "description": "A local-first planning workflow for mapping changed behavior to existing test evidence, missing edge cases, and focused next tests.",
+      "source": "extend/test-gap-planner",
+      "docs": "README.md",
+      "use_when": [
+        "A Worker slice changed behavior but verification coverage is uncertain.",
+        "The PM needs test evidence before audit or PR handoff.",
+        "A contributor wants a focused test plan before writing tests."
+      ],
+      "activation": "after_worker",
+      "outputs": [
+        "Test gap plan Markdown"
+      ],
+      "requires_approval": false,
+      "safe_by_default": true,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "tests",
+          "verification"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs/goals/<slug>/notes",
+        "tests",
+        "git diff --stat",
+        "git diff",
+        "verification output"
+      ],
+      "writes": [
+        "Test gap plan Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": []
+      },
+      "supports": {
+        "dry_run": true,
+        "credentials_required": false
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "test-gap-planner/README.md",
+          "sha256": "6db96f92a7a6320a42f07182d3975318165a67a37742974add94e7b548ffc916"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "test-gap-planner/extension.yaml",
+          "sha256": "13ad34e58a785851766ea149760d07daae320a87fa001ac93b0a75d2786238ac"
+        }
+      ]
+    },
+    {
+      "id": "release-readiness",
+      "name": "Release readiness",
+      "kind": "audit",
+      "version": "0.1.0",
+      "summary": "Produce a local release readiness brief covering scope, package metadata, verification, docs, examples, and publish blockers.",
+      "description": "A local-first release gate for package, CLI, extension, and release-facing documentation changes before publish or PR handoff.",
+      "source": "extend/release-readiness",
+      "docs": "README.md",
+      "use_when": [
+        "A goal changes package contents, CLI behavior, extension catalog entries, or release-facing docs.",
+        "The PM needs a pre-release gate before publishing or PR handoff.",
+        "Reviewers need release scope, verification, docs, and rollback notes in one place."
+      ],
+      "activation": "final_audit",
+      "outputs": [
+        "Release readiness brief"
+      ],
+      "requires_approval": false,
+      "safe_by_default": true,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "release",
+          "package",
+          "extensions"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs/goals/<slug>/notes",
+        "package.json",
+        "README.md",
+        "changelog",
+        "git diff --stat",
+        "verification output"
+      ],
+      "writes": [
+        "Release readiness Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": []
+      },
+      "supports": {
+        "dry_run": true,
+        "live_publish": false,
+        "credentials_required": false
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "release-readiness/README.md",
+          "sha256": "b84c214f629b647231118a78763086e2648116b830084444bb25346654026d4a"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "release-readiness/extension.yaml",
+          "sha256": "c4842964dcf5a257b6ab9149fcd90f4a4eb4c9abc794f29732cdae3f12ff8cab"
+        }
+      ]
+    },
+    {
+      "id": "dependency-upgrade-planner",
+      "name": "Dependency upgrade planner",
+      "kind": "planning",
+      "version": "0.1.0",
+      "summary": "Plan dependency upgrades with policy fit, migration risk, verification commands, and rollback notes before manifests change.",
+      "description": "A local-first planning workflow for dependency, toolchain, or lockfile changes that keeps project dependency policy visible.",
+      "source": "extend/dependency-upgrade-planner",
+      "docs": "README.md",
+      "use_when": [
+        "A goal proposes dependency, toolchain, or lockfile changes.",
+        "The repo has a dependency policy that must be preserved.",
+        "The PM needs a bounded upgrade plan before implementation."
+      ],
+      "activation": "before_worker",
+      "outputs": [
+        "Dependency upgrade plan Markdown"
+      ],
+      "requires_approval": false,
+      "safe_by_default": true,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "dependencies",
+          "toolchain",
+          "package"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "package manifests",
+        "lockfiles",
+        "dependency policy docs",
+        "supplied release notes",
+        "verification output"
+      ],
+      "writes": [
+        "Dependency upgrade plan Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": []
+      },
+      "supports": {
+        "dry_run": true,
+        "network_required": false,
+        "credentials_required": false
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "dependency-upgrade-planner/README.md",
+          "sha256": "adb779a3cbdcde5e04c981186083f217e559874c7b65b440da5bffeedaabbaae"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "dependency-upgrade-planner/extension.yaml",
+          "sha256": "087c4507dd984cbea28ebaa4c1fbad4a98094e20a499ec063f0554809434bdc2"
+        }
+      ]
+    },
+    {
+      "id": "security-review-brief",
+      "name": "Security review brief",
+      "kind": "review",
+      "version": "0.1.0",
+      "summary": "Prepare a local security review brief for changed auth, secrets, input, file, network, dependency, or public API surfaces.",
+      "description": "A local-first review workflow for identifying security-sensitive changed surfaces and focused reviewer questions.",
+      "source": "extend/security-review-brief",
+      "docs": "README.md",
+      "use_when": [
+        "A Worker slice touches auth, permissions, secrets, user input, file operations, dependency handling, or public APIs.",
+        "The PM needs explicit security evidence before audit or PR handoff.",
+        "Reviewers need focused security questions for a PR."
+      ],
+      "activation": "after_worker",
+      "outputs": [
+        "Security review brief"
+      ],
+      "requires_approval": false,
+      "safe_by_default": true,
+      "applies_to": {
+        "goal_state": "v2",
+        "surfaces": [
+          "security",
+          "code_review",
+          "pull_request"
+        ]
+      },
+      "reads": [
+        "docs/goals/<slug>/goal.md",
+        "docs/goals/<slug>/state.yaml",
+        "docs/goals/<slug>/notes",
+        "security policy docs",
+        "git diff --stat",
+        "git diff",
+        "verification output"
+      ],
+      "writes": [
+        "Security review Markdown"
+      ],
+      "side_effects": [
+        "none by default"
+      ],
+      "auth": {
+        "env": []
+      },
+      "supports": {
+        "dry_run": true,
+        "external_scanner": false,
+        "credentials_required": false
+      },
+      "source_of_truth": "local",
+      "files": [
+        {
+          "path": "README.md",
+          "url": "security-review-brief/README.md",
+          "sha256": "7c53aae1b23119987809ef17e223f52174ce0fe85529c49cec7cfc78c17c52c9"
+        },
+        {
+          "path": "extension.yaml",
+          "url": "security-review-brief/extension.yaml",
+          "sha256": "8c20f1fc34936a7fd1e1a6ec659caf94e25a2dc5a00c1c6785d60de88cf95633"
+        }
+      ]
     }
   ]
 }

--- a/extend/catalog.json
+++ b/extend/catalog.json
@@ -6,17 +6,19 @@
       "name": "GitHub PR workflow",
       "kind": "integration",
       "version": "0.1.0",
-      "summary": "Prepare GitHub pull request handoff text from Goal Maker receipts without requiring GitHub credentials.",
-      "description": "A local-first workflow for turning a Goal Maker board, receipts, changed files, and verification output into PR-ready Markdown while keeping state.yaml authoritative.",
+      "summary": "Prepare GitHub pull request handoff text and receipt-aligned commit boundaries from Goal Maker receipts without requiring GitHub credentials.",
+      "description": "A local-first workflow for turning a Goal Maker board, receipts, changed files, verification output, and commit boundaries into PR-ready Markdown while keeping state.yaml authoritative.",
       "source": "extend/github-pr-workflow",
       "docs": "README.md",
       "use_when": [
         "The goal produced code changes intended for GitHub review.",
         "The user asks to push, open a PR, or prepare review context.",
-        "The board has Worker receipts and verification commands worth summarizing."
+        "The board has Worker receipts and verification commands worth summarizing.",
+        "The branch should be decomposed into commits that map to completed Worker or PM receipts."
       ],
       "activation": "publish_handoff",
       "outputs": [
+        "Receipt-aligned commit plan",
         "PR handoff Markdown"
       ],
       "requires_approval": false,
@@ -32,9 +34,11 @@
         "docs/goals/<slug>/state.yaml",
         "docs/goals/<slug>/notes",
         "git status --short",
-        "git diff --stat"
+        "git diff --stat",
+        "git log --oneline <base>..HEAD"
       ],
       "writes": [
+        "Receipt-aligned local commits",
         "PR handoff Markdown"
       ],
       "side_effects": [
@@ -53,12 +57,12 @@
         {
           "path": "README.md",
           "url": "github-pr-workflow/README.md",
-          "sha256": "4cbc9eb4f905a759d461bb83e6c4b1fce5387ee8a5e84c7712f2f371965764ce"
+          "sha256": "51c84f737fbe73c321e7ca726767cb63c5b3e31f4099e758211ff0d3340d7625"
         },
         {
           "path": "extension.yaml",
           "url": "github-pr-workflow/extension.yaml",
-          "sha256": "641e998bd6453e1a9160b2fdabf3a251bbfd4f9354e62a61b789e15d8e6f147e"
+          "sha256": "75a207a6f8a62574860afa1cc42de464ef511920540c302f78130f0175930845"
         }
       ]
     },

--- a/extend/ci-failure-triage/README.md
+++ b/extend/ci-failure-triage/README.md
@@ -1,0 +1,39 @@
+# CI Failure Triage
+
+Turn failing checks into a compact diagnosis and next verification plan.
+
+This extension is local-first. It helps a Goal Maker run summarize failed commands, CI logs, recent Worker receipts, and changed files into likely causes and next steps. It does not connect to a CI provider by default.
+
+## Use When
+
+- `npm run check`, test, build, lint, or CI verification fails.
+- A goal needs to recover from a red verification slice.
+- Reviewers need a clear explanation of failure status and next diagnostic commands.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Worker receipts and notes
+- Failing command output
+- Relevant local logs
+- `git diff --stat`
+
+## Output
+
+A CI failure triage brief with:
+
+- Failed command summary
+- Suspected failure class
+- Changed files likely involved
+- Evidence from receipts and logs
+- Next local commands to run
+- Blocked external checks, if any
+- Recommended board update
+
+## Boundaries
+
+- This extension does not mark the board complete.
+- This extension does not fetch CI logs from GitHub Actions, CircleCI, Buildkite, or other providers by default.
+- Provider log fetching requires a separate credentialed workflow.
+- Missing live CI access should be recorded as a blocked check, not as a blocked local recovery task.

--- a/extend/ci-failure-triage/extension.yaml
+++ b/extend/ci-failure-triage/extension.yaml
@@ -1,0 +1,32 @@
+id: ci-failure-triage
+name: CI failure triage
+kind: recovery
+version: 0.1.0
+source_of_truth: local
+description: Summarize failing checks, logs, changed files, and receipts into a recovery-focused CI failure triage brief.
+use_when:
+  - A verification command, build, test, lint, or CI check failed.
+  - The PM needs a recovery task instead of continuing feature work.
+  - A reviewer needs concise failure context and next diagnostic commands.
+activation: blocked_task
+outputs:
+  - CI failure triage brief
+requires_approval: false
+safe_by_default: true
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs/goals/<slug>/notes
+  - failing command output
+  - local logs
+  - git diff --stat
+writes:
+  - Failure triage Markdown
+side_effects:
+  - none by default
+auth:
+  env: []
+supports:
+  dry_run: true
+  live_ci: false
+  credentials_required: false

--- a/extend/codebase-onboarding-map/README.md
+++ b/extend/codebase-onboarding-map/README.md
@@ -1,0 +1,39 @@
+# Codebase Onboarding Map
+
+Create a concise map of how a repository is organized and how to work in it.
+
+This extension is local-first. It helps a Goal Maker run turn repo files, commands, conventions, and recent receipts into an onboarding artifact for developers or future agents. It does not edit project docs by default.
+
+## Use When
+
+- A developer or agent is starting work in an unfamiliar repo.
+- A broad goal needs an evidence-backed repo map before implementation.
+- Reviewers need to understand package boundaries, commands, and conventions.
+
+## Inputs
+
+- `README.md`
+- `AGENTS.md`
+- `package.json` or equivalent manifests
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Existing examples, docs, and test directories
+- Relevant receipt notes
+
+## Output
+
+A codebase onboarding map with:
+
+- Repo purpose
+- Important directories and ownership boundaries
+- Common commands
+- Verification and release gates
+- Local conventions
+- Known risks or stale areas
+- Recommended first files to inspect
+
+## Boundaries
+
+- This extension produces an onboarding artifact; it does not refactor or rewrite docs automatically.
+- Generated maps should cite concrete files and commands.
+- The PM should create a bounded Worker task for any docs changes suggested by the map.

--- a/extend/codebase-onboarding-map/extension.yaml
+++ b/extend/codebase-onboarding-map/extension.yaml
@@ -1,0 +1,33 @@
+id: codebase-onboarding-map
+name: Codebase onboarding map
+kind: documentation
+version: 0.1.0
+source_of_truth: local
+description: Create a concise local onboarding map from repo files, commands, conventions, examples, and Goal Maker receipts.
+use_when:
+  - A developer or agent is starting work in an unfamiliar repo.
+  - A broad goal needs an evidence-backed repo map before implementation.
+  - Reviewers need package boundaries, commands, and conventions in one artifact.
+activation: before_worker
+outputs:
+  - Codebase onboarding map Markdown
+requires_approval: false
+safe_by_default: true
+reads:
+  - README.md
+  - AGENTS.md
+  - package manifests
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs
+  - examples
+  - tests
+writes:
+  - Codebase onboarding Markdown
+side_effects:
+  - none by default
+auth:
+  env: []
+supports:
+  dry_run: true
+  credentials_required: false

--- a/extend/dependency-upgrade-planner/README.md
+++ b/extend/dependency-upgrade-planner/README.md
@@ -1,0 +1,38 @@
+# Dependency Upgrade Planner
+
+Plan dependency updates before changing package manifests or lockfiles.
+
+This extension is local-first. It helps a Goal Maker run evaluate candidate dependency upgrades, runtime policy, migration notes, verification commands, and rollback options. It does not edit dependency files or contact a package registry by default.
+
+## Use When
+
+- A goal proposes updating dependencies, toolchain versions, or package manager files.
+- A repo has a dependency-free or low-dependency policy that must stay visible.
+- A Worker needs a bounded upgrade plan before touching manifests or lockfiles.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Repo dependency manifests and lockfiles
+- Existing dependency policy from README, AGENTS, or package docs
+- Relevant release notes supplied by the PM or user
+- Verification command output
+
+## Output
+
+A dependency upgrade plan with:
+
+- Proposed upgrade scope
+- Policy fit
+- Migration risk
+- Verification commands
+- Rollback plan
+- Blocked live checks or missing release-note evidence
+
+## Boundaries
+
+- This extension does not edit manifests or lockfiles.
+- It does not fetch registry metadata by default.
+- Network-backed version research should be a Scout task or explicitly approved extension behavior.
+- Dependency changes require a bounded Worker task.

--- a/extend/dependency-upgrade-planner/extension.yaml
+++ b/extend/dependency-upgrade-planner/extension.yaml
@@ -1,0 +1,33 @@
+id: dependency-upgrade-planner
+name: Dependency upgrade planner
+kind: planning
+version: 0.1.0
+source_of_truth: local
+description: Plan dependency upgrades with policy fit, migration risk, verification commands, and rollback notes before manifests change.
+use_when:
+  - A goal proposes dependency, toolchain, or lockfile changes.
+  - The repo has a dependency policy that must be preserved.
+  - The PM needs a bounded upgrade plan before implementation.
+activation: before_worker
+outputs:
+  - Dependency upgrade plan Markdown
+requires_approval: false
+safe_by_default: true
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - package manifests
+  - lockfiles
+  - dependency policy docs
+  - supplied release notes
+  - verification output
+writes:
+  - Dependency upgrade plan Markdown
+side_effects:
+  - none by default
+auth:
+  env: []
+supports:
+  dry_run: true
+  network_required: false
+  credentials_required: false

--- a/extend/docs-drift-audit/README.md
+++ b/extend/docs-drift-audit/README.md
@@ -1,0 +1,38 @@
+# Docs Drift Audit
+
+Catch documentation drift before a Goal Maker run claims completion.
+
+This extension is local-first. It helps compare the original request, changed files, commands, exported surfaces, and README/docs references so the PM can identify stale or missing documentation. It does not rewrite docs automatically.
+
+## Use When
+
+- A Worker slice changes behavior, commands, public files, extension metadata, or examples.
+- A final audit needs proof that docs and examples still match the implementation.
+- A PR handoff should call out docs updates or intentionally unchanged docs.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Worker receipts and notes
+- `git diff --stat`
+- `git diff`
+- README, docs, examples, and extension manifests relevant to changed files
+
+## Output
+
+A docs drift audit with:
+
+- Changed behavior or surface summary
+- Documentation locations checked
+- Missing, stale, or intentionally unchanged docs
+- Example artifact status
+- Suggested docs follow-up tasks
+- Completion risk
+
+## Boundaries
+
+- This extension reports drift; it does not silently edit docs.
+- The PM or a bounded Worker task must update docs if the audit finds required changes.
+- `state.yaml` remains the source of task truth.
+- Passing this audit is not enough for completion unless the final Judge/PM audit maps it back to the original outcome.

--- a/extend/docs-drift-audit/extension.yaml
+++ b/extend/docs-drift-audit/extension.yaml
@@ -1,0 +1,34 @@
+id: docs-drift-audit
+name: Docs drift audit
+kind: audit
+version: 0.1.0
+source_of_truth: local
+description: Compare changed behavior, receipts, and documentation surfaces to catch stale docs before completion or PR handoff.
+use_when:
+  - A Worker slice changed user-facing behavior, commands, extension metadata, or examples.
+  - The PM needs documentation coverage evidence before final audit.
+  - A PR handoff should explain docs updates or intentional docs non-changes.
+activation: final_audit
+outputs:
+  - Docs drift audit Markdown
+requires_approval: false
+safe_by_default: true
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs/goals/<slug>/notes
+  - README.md
+  - docs
+  - examples
+  - extend
+  - git diff --stat
+  - git diff
+writes:
+  - Docs drift audit Markdown
+side_effects:
+  - none by default
+auth:
+  env: []
+supports:
+  dry_run: true
+  credentials_required: false

--- a/extend/github-pr-workflow/README.md
+++ b/extend/github-pr-workflow/README.md
@@ -2,12 +2,13 @@
 
 Prepare GitHub pull request handoff text from a Goal Maker board without making GitHub the source of truth.
 
-This extension is intentionally local-first. It helps a goal run turn `state.yaml` receipts, verification commands, and the current diff into PR-ready context. It does not create a pull request, edit GitHub issues, or sync board state back from GitHub.
+This extension is intentionally local-first. It helps a goal run turn `state.yaml` receipts, verification commands, commit boundaries, and the current diff into PR-ready context. It does not create a pull request, edit GitHub issues, or sync board state back from GitHub.
 
 ## Use When
 
 - A Goal Maker run is ready for a pull request.
 - Reviewers need the original request, completed task receipts, changed files, and verification in one place.
+- The branch should be decomposed into commits that map to completed Worker or PM receipts.
 - The team wants a repeatable handoff format without requiring GitHub credentials during goal execution.
 
 ## Inputs
@@ -17,19 +18,31 @@ This extension is intentionally local-first. It helps a goal run turn `state.yam
 - Any receipt notes referenced from done tasks
 - `git status --short`
 - `git diff --stat`
+- `git log --oneline <base>..HEAD`
 - Relevant verification output
 
 ## Output
 
-A Markdown PR handoff with:
+A review-ready branch and Markdown PR handoff with:
 
 - PR title
 - Summary
 - Goal context
+- Commit plan mapped to Goal Maker receipts
 - Changed files
 - Verification
 - Review notes
 - Follow-up or blocked work
+
+## Commit Boundaries
+
+Use completed Worker or PM receipts as the default commit boundaries:
+
+- One implementation slice receipt should usually become one commit.
+- A commit should include the files needed for that slice to be locally coherent, including catalog/docs wiring when the slice adds an extension.
+- Do not combine unrelated receipts just because they were completed in one long goal run.
+- Do not split one receipt across multiple commits unless the receipt explicitly covers separate independently reviewable units.
+- Preserve blocked or credential-gated behavior in commit messages or PR notes when live verification is intentionally out of scope.
 
 See `examples/github-pr-workflow-extension/pr-handoff.md` for a complete example artifact.
 

--- a/extend/github-pr-workflow/extension.yaml
+++ b/extend/github-pr-workflow/extension.yaml
@@ -3,13 +3,15 @@ name: GitHub PR workflow
 kind: integration
 version: 0.1.0
 source_of_truth: local
-description: Prepare GitHub pull request handoff text from Goal Maker receipts without requiring GitHub credentials.
+description: Prepare review-ready GitHub pull request handoff text and commit boundaries from Goal Maker receipts without requiring GitHub credentials.
 use_when:
   - The goal produced code changes intended for GitHub review.
   - The user asks to push, open a PR, or prepare review context.
   - The board has Worker receipts and verification commands worth summarizing.
+  - The branch should be decomposed into commits that map to completed Worker or PM receipts.
 activation: publish_handoff
 outputs:
+  - Receipt-aligned commit plan
   - PR handoff Markdown
 requires_approval: false
 safe_by_default: true
@@ -19,7 +21,9 @@ reads:
   - docs/goals/<slug>/notes
   - git status --short
   - git diff --stat
+  - git log --oneline <base>..HEAD
 writes:
+  - Receipt-aligned local commits
   - PR handoff Markdown
 side_effects:
   - none by default

--- a/extend/linear-ticket-handoff/README.md
+++ b/extend/linear-ticket-handoff/README.md
@@ -1,0 +1,44 @@
+# Linear Ticket Handoff
+
+Prepare Linear-ready issue text from Goal Maker receipts.
+
+This extension is credential-gated for live Linear issue creation but useful locally without credentials. It helps a Goal Maker run convert scoped follow-up work, blockers, verification evidence, and review notes into ticket-ready Markdown. It does not create Linear issues by default.
+
+## Use When
+
+- A goal produces follow-up work that should become an issue.
+- A blocked task needs owner or team tracking.
+- The PM needs ticket-ready acceptance criteria from receipts and verification.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Receipt notes
+- Current dirty diff summary
+- Verification output
+
+## Output
+
+A Linear-ready ticket handoff with:
+
+- Suggested title
+- Problem statement
+- Context and evidence
+- Acceptance criteria
+- Verification commands
+- Blockers or missing credentials
+- Suggested labels or priority
+
+## Configuration
+
+Live Linear issue creation, if added later, requires:
+
+- `LINEAR_API_KEY`
+
+## Boundaries
+
+- `state.yaml` remains authoritative.
+- Missing Linear credentials should block only live issue creation, not local handoff text.
+- This extension does not create issues by default.
+- Live issue creation requires explicit approval and a separate Worker task.

--- a/extend/linear-ticket-handoff/extension.yaml
+++ b/extend/linear-ticket-handoff/extension.yaml
@@ -1,0 +1,33 @@
+id: linear-ticket-handoff
+name: Linear ticket handoff
+kind: integration
+version: 0.1.0
+source_of_truth: local
+description: Prepare Linear-ready issue text from Goal Maker receipts while treating live issue creation as credential-gated and approval-required.
+use_when:
+  - A goal produces follow-up work that should become an issue.
+  - A blocked task needs owner or team tracking.
+  - The PM needs ticket-ready acceptance criteria from receipts and verification.
+activation: publish_handoff
+outputs:
+  - Linear-ready ticket handoff Markdown
+requires_approval: true
+safe_by_default: false
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs/goals/<slug>/notes
+  - git status --short
+  - git diff --stat
+  - verification output
+writes:
+  - Linear ticket handoff Markdown
+side_effects:
+  - none by default
+auth:
+  env:
+    - LINEAR_API_KEY
+supports:
+  dry_run: true
+  live_linear: false
+  credentials_required: true

--- a/extend/release-readiness/README.md
+++ b/extend/release-readiness/README.md
@@ -1,0 +1,39 @@
+# Release Readiness
+
+Check whether a package, app, or extension change is ready to release.
+
+This extension is local-first. It helps a Goal Maker run assemble release evidence from changed files, package metadata, verification commands, docs, examples, and follow-up risks. It does not publish a release or change versions by default.
+
+## Use When
+
+- A goal changes package contents, CLI behavior, extension catalog entries, or release-facing docs.
+- The PM needs a pre-release gate before tagging, publishing, or PR handoff.
+- Reviewers need one place to inspect verification, docs, packaging, and rollback notes.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Worker receipts and notes
+- `package.json` or equivalent manifest
+- Changelog or release notes, when present
+- `git diff --stat`
+- Verification command output
+
+## Output
+
+A release readiness brief with:
+
+- Release scope
+- Package or artifact changes
+- Verification status
+- Docs and example status
+- Version/changelog status
+- Rollback or follow-up notes
+- Publish blockers
+
+## Boundaries
+
+- This extension does not run `npm publish`, create tags, or push branches.
+- Destructive or external release actions require explicit approval and a separate Worker task.
+- Missing credentials or release authority should block publish work, not local readiness checks.

--- a/extend/release-readiness/extension.yaml
+++ b/extend/release-readiness/extension.yaml
@@ -1,0 +1,34 @@
+id: release-readiness
+name: Release readiness
+kind: audit
+version: 0.1.0
+source_of_truth: local
+description: Produce a local release readiness brief covering scope, package metadata, verification, docs, examples, and publish blockers.
+use_when:
+  - A goal changes package contents, CLI behavior, extension catalog entries, or release-facing docs.
+  - The PM needs a pre-release gate before publishing or PR handoff.
+  - Reviewers need release scope, verification, docs, and rollback notes in one place.
+activation: final_audit
+outputs:
+  - Release readiness brief
+requires_approval: false
+safe_by_default: true
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs/goals/<slug>/notes
+  - package.json
+  - README.md
+  - changelog
+  - git diff --stat
+  - verification output
+writes:
+  - Release readiness Markdown
+side_effects:
+  - none by default
+auth:
+  env: []
+supports:
+  dry_run: true
+  live_publish: false
+  credentials_required: false

--- a/extend/security-review-brief/README.md
+++ b/extend/security-review-brief/README.md
@@ -1,0 +1,38 @@
+# Security Review Brief
+
+Prepare a local security review brief from changed files and Goal Maker receipts.
+
+This extension is local-first. It helps a Goal Maker run check security-sensitive surfaces such as auth, secrets, user input, file paths, network calls, dependencies, and public endpoints. It does not call a scanner or external security service by default.
+
+## Use When
+
+- A Worker slice touches auth, permissions, secrets, user input, file operations, dependency handling, or public APIs.
+- A final audit needs explicit security evidence.
+- Reviewers need focused security questions for a PR.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Worker receipts and notes
+- `git diff --stat`
+- `git diff`
+- Security-relevant project docs or policies
+- Verification command output
+
+## Output
+
+A security review brief with:
+
+- Security-sensitive changed surfaces
+- Trust boundary notes
+- Secrets and credential handling
+- Input/file/network risks
+- Dependency or supply-chain risks
+- Missing verification or reviewer questions
+
+## Boundaries
+
+- This extension does not approve a change as secure.
+- It does not run network scanners or upload code.
+- Findings that require code changes must become bounded Worker tasks.

--- a/extend/security-review-brief/extension.yaml
+++ b/extend/security-review-brief/extension.yaml
@@ -1,0 +1,33 @@
+id: security-review-brief
+name: Security review brief
+kind: review
+version: 0.1.0
+source_of_truth: local
+description: Prepare a local security review brief for changed auth, secrets, input, file, network, dependency, or public API surfaces.
+use_when:
+  - A Worker slice touches auth, permissions, secrets, user input, file operations, dependency handling, or public APIs.
+  - The PM needs explicit security evidence before audit or PR handoff.
+  - Reviewers need focused security questions for a PR.
+activation: after_worker
+outputs:
+  - Security review brief
+requires_approval: false
+safe_by_default: true
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs/goals/<slug>/notes
+  - security policy docs
+  - git diff --stat
+  - git diff
+  - verification output
+writes:
+  - Security review Markdown
+side_effects:
+  - none by default
+auth:
+  env: []
+supports:
+  dry_run: true
+  external_scanner: false
+  credentials_required: false

--- a/extend/slack-standup-digest/README.md
+++ b/extend/slack-standup-digest/README.md
@@ -1,0 +1,43 @@
+# Slack Standup Digest
+
+Prepare a Slack-ready status digest from Goal Maker receipts.
+
+This extension is credential-gated for live Slack delivery but useful locally without credentials. It helps a Goal Maker run summarize completed work, active blockers, verification status, and next steps in Slack-ready Markdown. It does not send a message by default.
+
+## Use When
+
+- A team wants a short async status update from a long-running goal.
+- A blocked task needs clear owner-visible context.
+- The PM needs to share progress without making Slack board truth.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Receipt notes
+- `git status --short`
+- Last verification output
+
+## Output
+
+A Slack-ready standup digest with:
+
+- Goal title and current status
+- Completed slices
+- Verification summary
+- Blockers and missing credentials
+- Next planned task
+- Optional live-send instructions
+
+## Configuration
+
+Live Slack delivery, if added later, requires:
+
+- `SLACK_BOT_TOKEN`
+
+## Boundaries
+
+- `state.yaml` remains authoritative.
+- Missing Slack credentials should block only live send, not local digest generation.
+- This extension does not send Slack messages by default.
+- Live delivery requires explicit approval and a separate Worker task.

--- a/extend/slack-standup-digest/extension.yaml
+++ b/extend/slack-standup-digest/extension.yaml
@@ -1,0 +1,32 @@
+id: slack-standup-digest
+name: Slack standup digest
+kind: integration
+version: 0.1.0
+source_of_truth: local
+description: Prepare a Slack-ready status digest from Goal Maker receipts while treating live delivery as credential-gated and approval-required.
+use_when:
+  - A team wants an async Slack-ready update from a long-running goal.
+  - A blocked task needs owner-visible context.
+  - The PM needs to share progress without making Slack board truth.
+activation: publish_handoff
+outputs:
+  - Slack-ready standup digest Markdown
+requires_approval: true
+safe_by_default: false
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs/goals/<slug>/notes
+  - git status --short
+  - verification output
+writes:
+  - Slack digest Markdown
+side_effects:
+  - none by default
+auth:
+  env:
+    - SLACK_BOT_TOKEN
+supports:
+  dry_run: true
+  live_slack: false
+  credentials_required: true

--- a/extend/test-gap-planner/README.md
+++ b/extend/test-gap-planner/README.md
@@ -1,0 +1,38 @@
+# Test Gap Planner
+
+Turn a changed diff and Goal Maker receipts into a focused test plan.
+
+This extension is local-first. It helps a Goal Maker run identify behavior that changed, tests that already ran, edge cases that remain weakly covered, and the smallest next tests worth adding. It does not write tests automatically.
+
+## Use When
+
+- A Worker slice changes behavior but verification only covers the happy path.
+- A Judge or PM needs to decide whether implementation proof is strong enough.
+- A contributor needs a reviewable test plan before adding more tests.
+
+## Inputs
+
+- `docs/goals/<slug>/goal.md`
+- `docs/goals/<slug>/state.yaml`
+- Worker receipts and notes
+- `git diff --stat`
+- `git diff`
+- Existing test files relevant to the changed surface
+- Verification command output
+
+## Output
+
+A test gap plan with:
+
+- Changed behavior summary
+- Existing test coverage evidence
+- Missing edge cases
+- Suggested smallest next tests
+- Manual checks, if automated tests are not practical
+- Completion risk
+
+## Boundaries
+
+- This extension plans tests; it does not edit test files.
+- A bounded Worker task must implement any required tests.
+- Passing existing tests is not treated as full coverage unless the plan maps tests to the changed behavior.

--- a/extend/test-gap-planner/extension.yaml
+++ b/extend/test-gap-planner/extension.yaml
@@ -1,0 +1,32 @@
+id: test-gap-planner
+name: Test gap planner
+kind: planning
+version: 0.1.0
+source_of_truth: local
+description: Identify weak test coverage and propose the smallest useful next tests from a diff, receipts, and verification output.
+use_when:
+  - A Worker slice changed behavior but verification coverage is uncertain.
+  - The PM needs test evidence before audit or PR handoff.
+  - A contributor wants a focused test plan before writing tests.
+activation: after_worker
+outputs:
+  - Test gap plan Markdown
+requires_approval: false
+safe_by_default: true
+reads:
+  - docs/goals/<slug>/goal.md
+  - docs/goals/<slug>/state.yaml
+  - docs/goals/<slug>/notes
+  - tests
+  - git diff --stat
+  - git diff
+  - verification output
+writes:
+  - Test gap plan Markdown
+side_effects:
+  - none by default
+auth:
+  env: []
+supports:
+  dry_run: true
+  credentials_required: false


### PR DESCRIPTION
# PR Handoff: Add Ten Goal Maker Extensions

## Suggested Title

Add ten Goal Maker extension workflows

## Summary

- Adds ten cataloged Goal Maker extensions for review, recovery, planning, documentation, audit, and team handoff workflows.
- Keeps each extension local-first where possible, with Slack and Linear live actions explicitly credential-gated and approval-required.
- Updates `extend/catalog.json`, `extend/README.md`, and `README.md` so the extensions are discoverable through the existing extension CLI.
- Captures scalability learnings from building extensions in batches.

## Goal Context

- Original request: create ten more high-value extensions for developers, use the GitHub PR workflow extension, and capture/apply Goal Maker scalability learnings.
- Target outcome: ten locally installable extension artifacts with docs, catalog metadata, strongest-available local verification, PR handoff proof, and learning capture.
- Completion proof: catalog/details/dry-run install checks pass, credential-gated missing-env behavior is verified locally, `npm run check` passes, and final audit maps all ten extensions to receipts.

## Extensions Added

- `ai-diff-risk-review`: local review brief for AI-assisted or agent-produced diffs.
- `ci-failure-triage`: recovery brief for failed verification or CI-like failures.
- `docs-drift-audit`: documentation drift audit before completion or PR handoff.
- `test-gap-planner`: focused test gap plan from changed behavior and receipts.
- `release-readiness`: release gate for scope, docs, package metadata, verification, and publish blockers.
- `dependency-upgrade-planner`: dependency upgrade plan with policy fit, risk, verification, and rollback notes.
- `security-review-brief`: focused local security review brief.
- `codebase-onboarding-map`: repo onboarding map from files, commands, conventions, and receipts.
- `slack-standup-digest`: Slack-ready status digest with live delivery credential-gated by `SLACK_BOT_TOKEN`.
- `linear-ticket-handoff`: Linear-ready issue text with live issue creation credential-gated by `LINEAR_API_KEY`.

## Changed Files

- `README.md`
- `extend/README.md`
- `extend/catalog.json`
- `extend/ai-diff-risk-review/README.md`
- `extend/ai-diff-risk-review/extension.yaml`
- `extend/ci-failure-triage/README.md`
- `extend/ci-failure-triage/extension.yaml`
- `extend/docs-drift-audit/README.md`
- `extend/docs-drift-audit/extension.yaml`
- `extend/test-gap-planner/README.md`
- `extend/test-gap-planner/extension.yaml`
- `extend/release-readiness/README.md`
- `extend/release-readiness/extension.yaml`
- `extend/dependency-upgrade-planner/README.md`
- `extend/dependency-upgrade-planner/extension.yaml`
- `extend/security-review-brief/README.md`
- `extend/security-review-brief/extension.yaml`
- `extend/codebase-onboarding-map/README.md`
- `extend/codebase-onboarding-map/extension.yaml`
- `extend/slack-standup-digest/README.md`
- `extend/slack-standup-digest/extension.yaml`
- `extend/linear-ticket-handoff/README.md`
- `extend/linear-ticket-handoff/extension.yaml`

## Verification

```bash
node internal/cli/goal-maker.mjs extend --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend ai-diff-risk-review --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend ci-failure-triage --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend docs-drift-audit --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend test-gap-planner --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend release-readiness --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend dependency-upgrade-planner --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend security-review-brief --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend codebase-onboarding-map --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend slack-standup-digest --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend linear-ticket-handoff --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend install <extension-id> --catalog-url extend/catalog.json --dry-run --json
SLACK_BOT_TOKEN= LINEAR_API_KEY= node internal/cli/goal-maker.mjs extend slack-standup-digest --catalog-url extend/catalog.json --json
SLACK_BOT_TOKEN= LINEAR_API_KEY= node internal/cli/goal-maker.mjs extend linear-ticket-handoff --catalog-url extend/catalog.json --json
npm run check
git diff --check
node goal-maker/scripts/check-goal-state.mjs docs/goals/ten-high-value-developer-extensions/state.yaml
```

## Review Notes

- The Slack and Linear extensions intentionally report missing env locally when credentials are absent; live delivery/issue creation is not part of this PR.
- `state.yaml` remains board truth. External handoff artifacts are review context only.
- Existing unrelated local modifications under `goal-maker/` were present before this run and are not part of the extension implementation receipts.
- Goal run artifacts under `docs/goals/ten-high-value-developer-extensions/` are local receipts for this requested run.

## Follow-Up

- Consider a catalog authoring helper that validates extension folder structure, manifest/catalog agreement, and checksum pins.
- Consider categorizing `extend/README.md` once the extension list grows further.
- Consider a reusable extension README/manifest template to reduce drift across local-first and credential-gated extensions.
