### PR TITLE
[codex] Clarify GitHub PR workflow commit boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The npm package is the stable core. Extensions live under `extend/` and move thr
 
 Extensions are not board truth. They may publish, report, intake, or add role guidance, but `state.yaml` remains authoritative.
 
-The first cataloged extension, `github-pr-workflow`, prepares GitHub PR handoff text from goal receipts without requiring GitHub credentials or making GitHub authoritative. The catalog also includes local-first review, recovery, planning, documentation, audit, and credential-gated handoff extensions such as `ai-diff-risk-review`, `ci-failure-triage`, `docs-drift-audit`, `test-gap-planner`, `release-readiness`, `dependency-upgrade-planner`, `security-review-brief`, `codebase-onboarding-map`, `slack-standup-digest`, and `linear-ticket-handoff`.
+The first cataloged extension, `github-pr-workflow`, prepares receipt-aligned commit boundaries and GitHub PR handoff text from goal receipts without requiring GitHub credentials or making GitHub authoritative. The catalog also includes local-first review, recovery, planning, documentation, audit, and credential-gated handoff extensions such as `ai-diff-risk-review`, `ci-failure-triage`, `docs-drift-audit`, `test-gap-planner`, `release-readiness`, `dependency-upgrade-planner`, `security-review-brief`, `codebase-onboarding-map`, `slack-standup-digest`, and `linear-ticket-handoff`.
 
 ## Running A Goal
 

--- a/extend/README.md
+++ b/extend/README.md
@@ -8,7 +8,7 @@ Each extension folder should contain the files referenced by `extend/catalog.jso
 
 ## Extensions
 
-- `github-pr-workflow`: prepares GitHub pull request handoff text from Goal Maker receipts while keeping `state.yaml` authoritative.
+- `github-pr-workflow`: prepares receipt-aligned commit boundaries and GitHub pull request handoff text while keeping `state.yaml` authoritative.
 - `codebase-onboarding-map`: creates a concise onboarding map from repo files, commands, conventions, and receipts.
 - `slack-standup-digest`: prepares Slack-ready status digests while keeping live delivery credential-gated.
 - `linear-ticket-handoff`: prepares Linear-ready issue text while keeping live issue creation credential-gated.

--- a/extend/catalog.json
+++ b/extend/catalog.json
@@ -6,7 +6,7 @@
       "name": "GitHub PR workflow",
       "kind": "integration",
       "version": "0.1.0",
-      "summary": "Prepare GitHub pull request handoff text and receipt-aligned commit boundaries from Goal Maker receipts without requiring GitHub credentials.",
+      "summary": "Prepare receipt-aligned commit boundaries and GitHub pull request handoff text from Goal Maker receipts without requiring GitHub credentials.",
       "description": "A local-first workflow for turning a Goal Maker board, receipts, changed files, verification output, and commit boundaries into PR-ready Markdown while keeping state.yaml authoritative.",
       "source": "extend/github-pr-workflow",
       "docs": "README.md",
@@ -57,7 +57,7 @@
         {
           "path": "README.md",
           "url": "github-pr-workflow/README.md",
-          "sha256": "51c84f737fbe73c321e7ca726767cb63c5b3e31f4099e758211ff0d3340d7625"
+          "sha256": "0cda5b3a9f4aca73cb2ffa15ae5126d22345c5f4c2eba36d51aaac237dfe22d5"
         },
         {
           "path": "extension.yaml",

--- a/extend/github-pr-workflow/README.md
+++ b/extend/github-pr-workflow/README.md
@@ -1,6 +1,6 @@
 # GitHub PR Workflow
 
-Prepare GitHub pull request handoff text from a Goal Maker board without making GitHub the source of truth.
+Prepare receipt-aligned commit boundaries and GitHub pull request handoff text from a Goal Maker board without making GitHub the source of truth.
 
 This extension is intentionally local-first. It helps a goal run turn `state.yaml` receipts, verification commands, commit boundaries, and the current diff into PR-ready context. It does not create a pull request, edit GitHub issues, or sync board state back from GitHub.
 


### PR DESCRIPTION
## Summary

Updates the GitHub PR workflow wording to reflect the behavior we clarified during review: it should prepare receipt-aligned commit boundaries as well as PR handoff text.

## Updated surfaces

- Root README extension summary
- `extend/README.md` extension list
- `extend/github-pr-workflow/README.md`
- `extend/catalog.json` summary and checksum pin

## Verification

```bash
node internal/cli/goal-maker.mjs extend github-pr-workflow --catalog-url extend/catalog.json --json
node internal/cli/goal-maker.mjs extend install github-pr-workflow --catalog-url extend/catalog.json --dry-run --json
git diff --check
```

Also rechecked catalog checksums locally.
