### PR TITLE
Sort completed board cards newest first

### DIFF
--- a/goalbuddy/surfaces/local-goal-board/scripts/lib/goal-board.mjs
+++ b/goalbuddy/surfaces/local-goal-board/scripts/lib/goal-board.mjs
@@ -142,8 +142,8 @@ export function buildColumns(tasks) {
     byColumn.get(task.column).push(task);
   }
 
-  for (const columnTasks of byColumn.values()) {
-    columnTasks.sort((left, right) => taskSortKey(left).localeCompare(taskSortKey(right)));
+  for (const [columnId, columnTasks] of byColumn.entries()) {
+    columnTasks.sort((left, right) => compareColumnTasks(columnId, left, right));
   }
 
   return [
@@ -320,6 +320,12 @@ function columnForStatus(status) {
 function taskSortKey(task) {
   const rank = task.status === "active" ? "0" : task.status === "queued" ? "1" : task.status === "blocked" ? "2" : "3";
   return `${rank}:${task.id}`;
+}
+
+function compareColumnTasks(columnId, left, right) {
+  const order = taskSortKey(left).localeCompare(taskSortKey(right));
+  if (columnId === "completed") return -order;
+  return order;
 }
 
 function normalizeStringList(value) {

--- a/goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
+++ b/goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
@@ -4,7 +4,7 @@ import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } f
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { createBoardPayload, writeBoardApp } from "../scripts/lib/goal-board.mjs";
+import { buildColumns, createBoardPayload, writeBoardApp } from "../scripts/lib/goal-board.mjs";
 import { parseArgs, startBoardServer } from "../scripts/local-goal-board.mjs";
 
 test("normalizes a dense goal into local board columns", () => {
@@ -21,6 +21,18 @@ test("normalizes a dense goal into local board columns", () => {
 
   const scout = payload.tasks.find((task) => task.id === "T001");
   assert.equal(scout.receipt.summary, "T001 completed during the progressive board motion demo.");
+});
+
+test("orders completed cards newest first while preserving queued order", () => {
+  const columns = buildColumns([
+    { id: "T001", column: "completed", status: "done" },
+    { id: "T002", column: "todo", status: "queued" },
+    { id: "T003", column: "completed", status: "done" },
+    { id: "T004", column: "todo", status: "queued" },
+  ]);
+
+  assert.deepEqual(columns.find((column) => column.id === "todo").tasks.map((task) => task.id), ["T002", "T004"]);
+  assert.deepEqual(columns.find((column) => column.id === "completed").tasks.map((task) => task.id), ["T003", "T001"]);
 });
 
 test("loads depth-1 subgoal boards into parent task payloads", () => {


### PR DESCRIPTION
## Summary
- Sort the Completed column in reverse task order so newly completed work stays at the top.
- Preserve existing ascending order for queued, active, and blocked columns.
- Add a regression test covering completed and queued column ordering.

## Rationale
The live board is most useful when it shows the latest progress without requiring the user to scroll. Completed cards are historical once they land, so keeping the newest completed task at the top makes the visible column reflect recent proof and momentum instead of stale earlier work.

## Tests
- node --test goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
- npm run check
- npm pack --dry-run