### PR TITLE
Show readable board card titles

### DIFF
--- a/goalbuddy/surfaces/local-goal-board/scripts/lib/goal-board.mjs
+++ b/goalbuddy/surfaces/local-goal-board/scripts/lib/goal-board.mjs
@@ -289,7 +289,7 @@ function titleForTask(task) {
 function compactTaskTitle(value) {
   const text = cleanText(value).replace(/\.$/, "");
   const routeMatch = text.match(/^Implement\b.*?\s(\/[A-Za-z0-9_./:-]+)\s+(route|queue slice|slice)\b/i);
-  if (routeMatch) return truncateTitle(`Implement ${routeMatch[1]} ${routeMatch[2]}`);
+  if (routeMatch) return `Implement ${routeMatch[1]} ${routeMatch[2]}`;
 
   const firstClause = text
     .split(/(?<=[.!?])\s+|\s+(?:Use only|Add|Match|Render|Clearly label|Do not)\b/i)[0]
@@ -300,14 +300,7 @@ function compactTaskTitle(value) {
     .replace(/[.;:,]\s*$/, "")
     .trim();
 
-  return truncateTitle(firstClause || text);
-}
-
-function truncateTitle(value, maxLength = 82) {
-  const text = cleanText(value).replace(/\.$/, "");
-  if (text.length <= maxLength) return text;
-  const shortened = text.slice(0, maxLength + 1).replace(/\s+\S*$/, "").trim();
-  return `${shortened || text.slice(0, maxLength).trim()}...`;
+  return firstClause || text;
 }
 
 function columnForStatus(status) {
@@ -1503,8 +1496,13 @@ h1 {
 .task-title {
   margin: 0;
   color: #2f3437;
+  display: -webkit-box;
   font-size: 15px;
   line-height: 1.35;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
 }
 
 .card-footer {

--- a/goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
+++ b/goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
@@ -37,10 +37,10 @@ test("loads depth-1 subgoal boards into parent task payloads", () => {
   assert.equal(parentTask.subgoal.board.tasks.find((task) => task.id === "T002").subgoal, null);
 });
 
-test("uses compact card titles while preserving full objectives", () => {
-  const root = mkdtempSync(join(tmpdir(), "goalbuddy-compact-titles-"));
+test("uses readable card titles while preserving full objectives", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-readable-titles-"));
   try {
-    const goalDir = join(root, "compact-titles");
+    const goalDir = join(root, "readable-titles");
     mkdirSync(join(goalDir, "notes"), { recursive: true });
     writeFileSync(join(goalDir, "state.yaml"), `version: 2
 goal:
@@ -70,6 +70,13 @@ tasks:
     status: queued
     objective: "This objective can stay much more detailed because it belongs in the modal, not on the card face."
     receipt: null
+  - id: T004
+    title: "Run installed-Cursor runtime proof for a named model request through the local BYOK bridge"
+    type: worker
+    assignee: Worker
+    status: queued
+    objective: "Run installed-Cursor runtime proof for a named model request through the local BYOK bridge."
+    receipt: null
 `);
 
     const payload = createBoardPayload(goalDir);
@@ -77,6 +84,10 @@ tasks:
     assert.equal(payload.tasks.find((task) => task.id === "T001").objective.includes("admin_seed_metrics.enrichment_qa"), true);
     assert.equal(payload.tasks.find((task) => task.id === "T002").title, "Implement /contacts/con_aaron_keller route");
     assert.equal(payload.tasks.find((task) => task.id === "T003").title, "Human-friendly release title");
+    assert.equal(
+      payload.tasks.find((task) => task.id === "T004").title,
+      "Run installed-Cursor runtime proof for a named model request through the local BYOK bridge",
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -249,6 +260,7 @@ test("writes a minimal GoalBuddy web app into the goal directory", () => {
   assert.match(css, /:root\[data-theme="dark"\]/);
   assert.match(css, /:root\[data-density="compact"\] \.task-card/);
   assert.match(css, /:root\[data-completed-visibility="collapse"\]/);
+  assert.match(css, /-webkit-line-clamp: 5/);
   assert.match(css, /\.subgoal-board/);
   assert.match(css, /\.board-error/);
   assert.match(js, /new EventSource\("\.\/events"\)/);


### PR DESCRIPTION
## Summary
- Preserve generated board card titles in the payload instead of adding data-level ellipses.
- Keep the existing objective-to-title compaction for route/slice-style tasks.
- Clamp the rendered card title block at five lines so unusually long titles stay bounded.

## Rationale
The card face is the main scanning surface for the board, so normal task titles should remain readable without opening the detail modal. This keeps the full title available to the card and modal while still bounding very long titles visually.

## Alternative considered
Hover-to-expand could be a nice middle ground for users who prefer denser card stacks: compact by default, fuller title on hover or focus. I left that out of this PR to keep the change focused and because it likely fits better as a future display preference alongside compact/full title modes.

## Tests
- node --test goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
- npm run check
- npm pack --dry-run