### PR TITLE
Add Codex reset cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ To verify a Codex install:
 npx goalbuddy doctor --target codex --goal-ready
 ```
 
+To remove GoalBuddy-owned Codex runtime surfaces:
+
+```bash
+npx goalbuddy reset --target codex
+```
+
+Native `codex plugin remove goalbuddy@goalbuddy` only removes the native plugin surface. GoalBuddy also owns the `goal_*.toml` agent files it installed, its Codex plugin cache, its marketplace entry, and old personal skill folders from earlier installs. Use `goalbuddy reset --target codex` when you want those GoalBuddy-owned files removed too.
+
 ## What It Creates
 
 ```text

--- a/internal/cli/goal-maker.mjs
+++ b/internal/cli/goal-maker.mjs
@@ -111,6 +111,17 @@ async function main() {
         doctorClaude();
       }
       break;
+    case "reset":
+      if (wantsHelp()) {
+        usage();
+        break;
+      }
+      if (targetMode() !== "codex") {
+        console.error("Reset currently supports --target codex only.");
+        process.exit(2);
+      }
+      resetCodex();
+      break;
     case "check-update":
     case "update-check":
       checkUpdate();
@@ -203,6 +214,7 @@ Usage:
   ${canonicalCliName} update [--target claude|codex] [--claude-home <path>] [--codex-home <path>] [--json]
   ${canonicalCliName} agents [--target claude|codex] [--claude-home <path>] [--codex-home <path>] [--force]
   ${canonicalCliName} doctor [--target claude|codex] [--claude-home <path>] [--codex-home <path>] [--goal-ready]
+  ${canonicalCliName} reset --target codex [--codex-home <path>] [--json]
   ${canonicalCliName} check-update [--json]
   ${canonicalCliName} board <docs/goals/slug> [--host <host>] [--port <port>] [--once] [--json]
   ${canonicalCliName} prompt <docs/goals/slug> [--task T###] [--board <path/to/state.yaml>] [--json]
@@ -782,8 +794,95 @@ function cleanupLegacyCodexSkills() {
   return removed;
 }
 
+function resetCodex() {
+  const configPath = join(codexHome(), "config.toml");
+  const removedConfigSections = [];
+  if (existsSync(configPath)) {
+    const existing = readFileSync(configPath, "utf8");
+    let updated = existing;
+    for (const header of [`[plugins."${pluginName}@${pluginName}"]`, `[marketplaces.${pluginName}]`]) {
+      const next = removeTomlTable(updated, header);
+      if (next !== updated) {
+        removedConfigSections.push(header);
+        updated = next;
+      }
+    }
+    if (updated !== existing) writeFileSync(configPath, updated);
+  }
+
+  const removedPluginCachePaths = [];
+  const cacheRoot = pluginCacheOwnerRoot();
+  if (existsSync(cacheRoot)) {
+    rmSync(cacheRoot, { recursive: true, force: true });
+    removedPluginCachePaths.push(cacheRoot);
+  }
+
+  const removedAgents = [];
+  const agentsRoot = join(codexHome(), "agents");
+  for (const file of requiredAgentFiles) {
+    const path = join(agentsRoot, file);
+    if (!existsSync(path)) continue;
+    rmSync(path, { recursive: true, force: true });
+    removedAgents.push(path);
+  }
+
+  const removedLegacySkillPaths = cleanupLegacyCodexSkills();
+  const report = {
+    reset: true,
+    target: "codex",
+    codex_home: codexHome(),
+    config_path: configPath,
+    removed_config_sections: removedConfigSections,
+    removed_plugin_cache_paths: removedPluginCachePaths,
+    removed_agents: removedAgents,
+    removed_legacy_skill_paths: removedLegacySkillPaths,
+  };
+
+  if (hasFlag("--json")) {
+    printJson(report);
+    return report;
+  }
+
+  console.log(`Reset ${canonicalProductName} Codex-owned runtime files`);
+  console.log(`Config sections: ${removedConfigSections.length ? removedConfigSections.join(", ") : "none"}`);
+  console.log(`Plugin cache: ${removedPluginCachePaths.length ? removedPluginCachePaths.join(", ") : "none"}`);
+  console.log(`Agents: ${removedAgents.length ? removedAgents.join(", ") : "none"}`);
+  console.log(`Legacy personal skills: ${removedLegacySkillPaths.length ? removedLegacySkillPaths.join(", ") : "none"}`);
+  return report;
+}
+
+function removeTomlTable(text, header) {
+  const normalized = text.endsWith("\n") || text.length === 0 ? text : `${text}\n`;
+  const lines = normalized.split("\n");
+  const output = [];
+  let skipping = false;
+  let removed = false;
+  const descendantPrefix = `${header.slice(0, -1)}.`;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === header || trimmed.startsWith(descendantPrefix)) {
+      skipping = true;
+      removed = true;
+      continue;
+    }
+    if (skipping && /^\s*\[/.test(line)) {
+      skipping = trimmed.startsWith(descendantPrefix);
+      if (skipping) continue;
+    }
+    if (!skipping) output.push(line);
+  }
+
+  if (!removed) return text;
+  return output.join("\n").replace(/\n{3,}/g, "\n\n").replace(/\n*$/, "\n");
+}
+
+function pluginCacheOwnerRoot() {
+  return join(codexHome(), "plugins", "cache", pluginName);
+}
+
 function pluginCacheRoot(version) {
-  return join(codexHome(), "plugins", "cache", pluginName, pluginName, version);
+  return join(pluginCacheOwnerRoot(), pluginName, version);
 }
 
 function enablePluginConfig() {

--- a/internal/test/goal-maker-cli.test.mjs
+++ b/internal/test/goal-maker-cli.test.mjs
@@ -697,6 +697,95 @@ test("plugin install removes stale personal Codex GoalBuddy skills", () => {
   }
 });
 
+test("reset removes only GoalBuddy-owned Codex runtime surfaces", () => {
+  const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    const configPath = join(codexHome, "config.toml");
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(configPath, [
+      '[plugins."goalbuddy@goalbuddy"]',
+      "enabled = true",
+      "",
+      '[plugins."goalbuddy@goalbuddy".settings]',
+      'token = "remove-me"',
+      "",
+      '[plugins."github@openai-curated"]',
+      "enabled = true",
+      "",
+      "[marketplaces.goalbuddy]",
+      'source = "tolibear/goalbuddy"',
+      'source_type = "git"',
+      "",
+      "[marketplaces.goalbuddy.settings]",
+      'token = "remove-me-too"',
+      "",
+      "[marketplaces.other]",
+      'source = "openai/curated"',
+      "",
+    ].join("\n"));
+
+    const cacheRoot = join(codexHome, "plugins", "cache", "goalbuddy", "goalbuddy", packageVersion);
+    mkdirSync(cacheRoot, { recursive: true });
+    writeFileSync(join(cacheRoot, "sentinel.txt"), "cached\n");
+
+    const agentsRoot = join(codexHome, "agents");
+    mkdirSync(agentsRoot, { recursive: true });
+    for (const file of ["goal_judge.toml", "goal_scout.toml", "other.toml"]) {
+      writeFileSync(join(agentsRoot, file), `${file}\n`);
+    }
+    mkdirSync(join(agentsRoot, "goal_worker.toml"), { recursive: true });
+    writeFileSync(join(agentsRoot, "goal_worker.toml", "sentinel.txt"), "corrupt agent path\n");
+
+    const staleSkill = join(codexHome, "skills", "goalbuddy");
+    const staleAlias = join(codexHome, "skills", "goal-maker");
+    mkdirSync(staleSkill, { recursive: true });
+    mkdirSync(staleAlias, { recursive: true });
+    writeFileSync(join(staleSkill, "SKILL.md"), "stale GoalBuddy skill\n");
+    writeFileSync(join(staleAlias, "SKILL.md"), "stale Goal Maker alias\n");
+
+    const reset = runGoalMaker(["reset", "--target", "codex", "--codex-home", codexHome, "--json"]);
+    assert.equal(reset.status, 0, reset.stderr || reset.stdout);
+    const report = JSON.parse(reset.stdout);
+    assert.deepEqual(report.removed_config_sections, [
+      '[plugins."goalbuddy@goalbuddy"]',
+      "[marketplaces.goalbuddy]",
+    ]);
+    assert.match(report.removed_plugin_cache_paths[0], pathSuffixPattern("plugins", "cache", "goalbuddy"));
+    assert.equal(report.removed_agents.length, 3);
+    assert.equal(report.removed_legacy_skill_paths.length, 2);
+
+    const config = readFileSync(configPath, "utf8");
+    assert.doesNotMatch(config, /goalbuddy@goalbuddy/);
+    assert.doesNotMatch(config, /\[marketplaces\.goalbuddy\]/);
+    assert.doesNotMatch(config, /remove-me/);
+    assert.doesNotMatch(config, /remove-me-too/);
+    assert.match(config, /\[plugins\."github@openai-curated"\]/);
+    assert.match(config, /\[marketplaces\.other\]/);
+    assert.equal(existsSync(join(codexHome, "plugins", "cache", "goalbuddy")), false);
+    assert.equal(existsSync(join(agentsRoot, "goal_worker.toml")), false);
+    assert.equal(existsSync(join(agentsRoot, "other.toml")), true);
+    assert.equal(existsSync(staleSkill), false);
+    assert.equal(existsSync(staleAlias), false);
+
+    const secondReset = runGoalMaker(["reset", "--codex-home", codexHome, "--json"]);
+    assert.equal(secondReset.status, 0, secondReset.stderr || secondReset.stdout);
+    const secondReport = JSON.parse(secondReset.stdout);
+    assert.deepEqual(secondReport.removed_config_sections, []);
+    assert.deepEqual(secondReport.removed_plugin_cache_paths, []);
+    assert.deepEqual(secondReport.removed_agents, []);
+    assert.deepEqual(secondReport.removed_legacy_skill_paths, []);
+
+    const doctor = runGoalMaker(["doctor", "--codex-home", codexHome], { env: fakeCodexEnv(root) });
+    assert.equal(doctor.status, 1, doctor.stderr || doctor.stdout);
+    const doctorReport = JSON.parse(doctor.stdout);
+    assert.deepEqual(doctorReport.installed_agents, []);
+    assert.deepEqual(doctorReport.stale_agents, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("plugin install ignores non-version cache directories", () => {
   const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
   try {


### PR DESCRIPTION
## Summary
- add `goalbuddy reset --target codex` to remove GoalBuddy-owned Codex plugin config, marketplace registration, plugin cache, bundled agents, and stale personal skill folders
- document the boundary that native `codex plugin remove goalbuddy@goalbuddy` does not remove GoalBuddy-owned agent/config leftovers
- remove nested GoalBuddy TOML tables and corrupted directory-shaped agent paths during reset
- report removed paths and config sections in JSON for auditable cleanup
- preserve unrelated Codex plugin config, marketplace entries, and agent files

Covers the third PR slice from #26: explicit reset cleanup.

## Verification
- `npm run check`