### PR TITLE
fix: restore Claude Code's native /goal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.3: Restore Claude's Native /goal (2026-08-05)
+
+- **Claude Code keeps its native `/goal`.** GoalBuddy now installs its execution loop as `/goalbuddy`, removing the namespace collision introduced in 0.4.0.
+- **Safe migration.** Install and update remove the old `~/.claude/commands/goal.md` only when the file is GoalBuddy-authored. User-authored files are preserved and reported as a collision for the owner to resolve.
+- **Harness-specific handoffs.** Goal Prep, `init`, and `resume` now print Codex `/goal` and Claude Code `/goalbuddy` commands explicitly while both harnesses continue to share the same repo-native board.
+- **Regression coverage.** Tests verify fresh installs, owned-command migration, preservation of user files, doctor collision detection, packed npm contents, and the split continuation commands.
+
 ## 0.4.2: Honest Continuation State (2026-07-31)
 
 - **Machine-checkable stop decisions.** `goalbuddy can-stop <goal>` fails closed while a valid active task remains and permits exit only for a receipt-backed complete outcome or the exact validated terminal approval wait.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <strong>A simple operating loop for long <code>/goal</code> runs.</strong>
+  <strong>A simple operating loop for long goal runs.</strong>
 </p>
 
 <p align="center">
@@ -16,9 +16,9 @@
   <a href="https://goalbuddy.dev"><img alt="goalbuddy.dev" src="https://img.shields.io/badge/site-goalbuddy.dev-684cff?style=flat-square"></a>
 </p>
 
-GoalBuddy helps Codex and Claude Code stay oriented during long coding tasks by giving native `/goal` a finish line, a live work surface, and a proof loop.
+GoalBuddy helps Codex and Claude Code stay oriented during long coding tasks by giving each harness's execution command a finish line, a live work surface, and a proof loop.
 
-It gives `/goal` a small local workspace: a charter, a goal oracle, a board, notes, receipts, and a clear next task. The work stays in your repo, so a run can pause, resume, verify, and keep going without re-inventing the plan every turn.
+It gives a goal run a small local workspace: a charter, a goal oracle, a board, notes, receipts, and a clear next task. The work stays in your repo, so a run can pause, resume, verify, and keep going without re-inventing the plan every turn.
 
 ## Start Here
 
@@ -42,9 +42,9 @@ In Claude Code, use:
 /goal-prep
 ```
 
-Goal Prep creates the board and prints the exact `/goal` command to run next. That is the whole path.
+Goal Prep creates the board and prints the exact command to run next. That is the whole path.
 
-In Claude Code, GoalBuddy installs a real `/goal` command that runs the execution loop. In Codex, native `/goal` is the separate OpenAI-gated feature GoalBuddy prepares boards for.
+In Codex, native `/goal` runs the board. In Claude Code, GoalBuddy installs `/goalbuddy` so Claude's own `/goal` command remains untouched.
 
 ## Cross-Harness Goals
 
@@ -52,13 +52,13 @@ In Claude Code, GoalBuddy installs a real `/goal` command that runs the executio
   <img src="internal/assets/goalbuddy-v0.4.0-release.png" alt="GoalBuddy 0.4.0: Cross-Harness Goals — one board, any agent" width="100%">
 </p>
 
-Harnesses churn; repos persist. A GoalBuddy board lives in your repo as plain files, so the goal outlives whichever tool started it: begin a goal in Codex, resume it in Claude Code tomorrow — or the other way around — with the same command.
+Harnesses churn; repos persist. A GoalBuddy board lives in your repo as plain files, so the goal outlives whichever tool started it: begin a goal in Codex, resume it in Claude Code tomorrow, or the other way around, using the command for that harness.
 
 ```bash
 npx goalbuddy resume
 ```
 
-`resume` lists every live board in the repo with its status, active task, and the exact `/goal Follow docs/goals/<slug>/goal.md.` command to continue, which is identical in both harnesses. Receipts can record which harness performed each task, so the board's history survives the handoff intact.
+`resume` lists every live board in the repo with its status, active task, and both continuation commands: Codex `/goal Follow docs/goals/<slug>/goal.md.` and Claude Code `/goalbuddy Follow docs/goals/<slug>/goal.md.`. Receipts can record which harness performed each task, so the board's history survives the handoff intact.
 
 Boards can also mix vendors within a single run — a Claude judge and a Codex worker on the same board:
 
@@ -134,7 +134,7 @@ Judge chooses the largest safe useful slice.
 
 Worker completes the whole assigned slice and leaves a receipt.
 
-`/goal` keeps the loop honest until a final Judge/PM audit maps receipts and verification back to the oracle and records the full outcome complete.
+The execution command keeps the loop honest until a final Judge/PM audit maps receipts and verification back to the oracle and records the full outcome complete.
 
 ## Slice Sizing
 
@@ -178,7 +178,7 @@ Multiple local boards reuse one readable `goalbuddy.localhost` hub with an in-he
 
 Custom external integrations should be built as ordinary repo work with a concrete implementation plan, not installed from a GoalBuddy catalog.
 
-See [GoalBuddy 0.4.2: Honest Continuation State](docs/releases/0.4.2.md) for the latest release notes.
+See [GoalBuddy 0.4.3: Restore Claude's Native /goal](docs/releases/0.4.3.md) for the latest release notes.
 
 <p align="center">
   <img src="internal/assets/goalbuddy-live-board.jpg" alt="GoalBuddy local live board open next to Codex while Scout, Judge, and Worker tasks populate." width="100%">
@@ -196,7 +196,7 @@ See [GoalBuddy 0.4.2: Honest Continuation State](docs/releases/0.4.2.md) for the
 
 GoalBuddy is MIT licensed and published on npm.
 
-The implementation lives in this repo, but the happy path is intentionally tiny: install it, run Goal Prep, then let `/goal` work from the generated files.
+The implementation lives in this repo, but the happy path is intentionally tiny: install it, run Goal Prep, then use the printed Codex `/goal` or Claude Code `/goalbuddy` command.
 
 For release process details, see [docs/releases](docs/releases/README.md).
 

--- a/docs/releases/0.4.3.md
+++ b/docs/releases/0.4.3.md
@@ -1,0 +1,34 @@
+# GoalBuddy 0.4.3: Restore Claude's Native `/goal`
+
+GoalBuddy now uses `/goalbuddy` for execution in Claude Code. Codex continues to use its native `/goal` feature. Both commands read and update the same repo-native GoalBuddy board.
+
+## What Changed
+
+- Fresh Claude Code installs create `~/.claude/commands/goalbuddy.md`, not `goal.md`.
+- Updates remove the old `~/.claude/commands/goal.md` only when GoalBuddy can identify it as a GoalBuddy-authored file.
+- A user-authored `goal.md` is never deleted. The installer warns, and `goalbuddy doctor --target claude` reports that Claude's native `/goal` remains shadowed.
+- Goal Prep, `goalbuddy init`, and `goalbuddy resume` print the correct continuation command for each harness.
+
+## Continue a Board
+
+In Codex:
+
+```text
+/goal Follow docs/goals/<slug>/goal.md.
+```
+
+In Claude Code:
+
+```text
+/goalbuddy Follow docs/goals/<slug>/goal.md.
+```
+
+The command names differ, but `state.yaml`, receipts, task ownership, and completion proof remain portable between the two harnesses.
+
+## Upgrade
+
+```bash
+npx goalbuddy@latest update
+```
+
+Restart Claude Code after updating, then use `/goalbuddy` for GoalBuddy execution. Your native `/goal` command is available again when no separate `~/.claude/commands/goal.md` file exists.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -2,6 +2,7 @@
 
 Historical release notes live next to this process doc:
 
+- [0.4.3: Restore Claude's Native /goal](0.4.3.md)
 - [0.4.2: Honest Continuation State](0.4.2.md)
 - [0.4.1: Installed Contract Fixes](0.4.1.md)
 - [0.4.0: Cross-Harness Goals](0.4.0.md)
@@ -56,7 +57,7 @@ node internal/cli/check-publish-version.mjs
 ```
 
 3. Commit and push the version change.
-4. Create and publish a GitHub release whose tag matches the package version, for example `v0.4.2`. The workflow refuses to publish when the release tag and `package.json` version differ.
+4. Create and publish a GitHub release whose tag matches the package version, for example `v0.4.3`. The workflow refuses to publish when the release tag and `package.json` version differ.
 5. Confirm the GitHub Actions workflow `Publish npm package` completed.
 6. Verify npm:
 

--- a/goalbuddy/SKILL.md
+++ b/goalbuddy/SKILL.md
@@ -5,7 +5,7 @@ description: Goal Prep for GoalBuddy. Use for broad, long-running, stalled, vagu
 
 # Goal Prep
 
-`$goal-prep` (Codex) or `/goal-prep` (Claude Code) prepares a GoalBuddy board. It does not start `/goal` automatically, but the board and starter `/goal` command must be shaped so the next run continues into safe execution by default.
+`$goal-prep` (Codex) or `/goal-prep` (Claude Code) prepares a GoalBuddy board. It does not start execution automatically, but the board and harness-specific starter command must be shaped so the next run continues into safe execution by default.
 
 GoalBuddy is for autonomous, long-running Codex or Claude Code work where the PM thread may need to discover the work, define tasks, sequence them, delegate them, execute them, verify them, and keep going without the human decomposing every step.
 
@@ -27,12 +27,12 @@ No oracle, no serious goal. A goal oracle is the observable signal that tells th
 
 There are two different modes:
 
-- `$goal-prep`: prepare intake, `goal.md`, `state.yaml`, and the starter `/goal` command, then stop.
-- `/goal Follow docs/goals/<slug>/goal.md.`: execute the board, including Scout/Judge/Worker work.
+- `$goal-prep` or `/goal-prep`: prepare intake, `goal.md`, `state.yaml`, and the starter execution commands, then stop.
+- Codex `/goal Follow docs/goals/<slug>/goal.md.` or Claude Code `/goalbuddy Follow docs/goals/<slug>/goal.md.`: execute the board, including Scout/Judge/Worker work.
 
 This boundary is strict. `$goal-prep` is not a lightweight `/goal`; it is a board compiler.
 
-This document is the prep-mode contract plus the shared board model. The `/goal` execution contract lives in `references/goal-execution.md` next to this file; read it at the start of every `/goal` run. If it cannot be read, these execution invariants still hold: `state.yaml` is board truth; exactly one active task unless disjoint write scopes are proven; Scout and Judge tasks are read-only; Worker tasks write only inside `allowed_files` and run their `verify` commands; every completed, blocked, or escalated task gets a receipt; the goal completes only through a final Judge or PM audit that maps receipts and verification back to the original outcome (recording `full_outcome_complete: true` for continuous execution goals).
+This document is the prep-mode contract plus the shared board model. The execution contract lives in `references/goal-execution.md` next to this file; read it at the start of every Codex `/goal` or Claude Code `/goalbuddy` run. If it cannot be read, these execution invariants still hold: `state.yaml` is board truth; exactly one active task unless disjoint write scopes are proven; Scout and Judge tasks are read-only; Worker tasks write only inside `allowed_files` and run their `verify` commands; every completed, blocked, or escalated task gets a receipt; the goal completes only through a final Judge or PM audit that maps receipts and verification back to the original outcome (recording `full_outcome_complete: true` for continuous execution goals).
 
 During a `$goal-prep` turn, do not perform the user's requested work, even if the work looks read-only, preparatory, or obviously useful. Do not refresh or load named skills, inspect implementation files, browse reference repos, research design inspiration, generate design plans, generate images/assets, run app-specific checks, or edit product files. Put those actions into Scout, Judge, Worker, or PM tasks for the later `/goal` run.
 
@@ -44,8 +44,8 @@ Allowed `$goal-prep` actions:
 - create and open the built-in local GoalBuddy board surface for the goal unless the user opts out;
 - optionally run the GoalBuddy board checker against that `state.yaml`;
 - verify GoalBuddy agent availability, if this can be done without touching implementation work, and record `installed`, `bundled_not_installed`, `missing`, or `unknown` truthfully;
-- print exactly `/goal Follow docs/goals/<slug>/goal.md.`;
-- ask whether to start `/goal`, refine the board, or stop.
+- print both exact execution commands: Codex `/goal Follow docs/goals/<slug>/goal.md.` and Claude Code `/goalbuddy Follow docs/goals/<slug>/goal.md.`;
+- ask whether to start execution, refine the board, or stop.
 
 If the prompt names another skill or tool, such as "use the taste skill", "refresh the taste skill", "look at this repo", "use browser", or "generate assets", record that requirement in the charter and seed tasks. Do not load that skill, browse that repo, or generate those assets during `$goal-prep`.
 
@@ -175,7 +175,7 @@ Do:
 - seed a role-tagged task board that matches the input shape;
 - make the first active task safe;
 - verify Scout, Worker, and Judge agent availability or record an explicit truthful state;
-- print the exact command `/goal Follow docs/goals/<slug>/goal.md.`;
+- print the exact Codex command `/goal Follow docs/goals/<slug>/goal.md.` and Claude Code command `/goalbuddy Follow docs/goals/<slug>/goal.md.`;
 - ask whether to start now, refine `goal.md`, or stop.
 
 Do not:
@@ -380,10 +380,11 @@ A task's `assignee` determines the agent. The task card is the order. The receip
 
 Only the main `/goal` PM may choose the active task, update the board, mark tasks done, or mark the goal complete. The PM thinking policy and the execution quality commands (including the subagent dispatch rules) live in `references/goal-execution.md`.
 
-## Default `/goal` Shape
+## Default Execution Shape
 
 ```text
-/goal Follow docs/goals/<slug>/goal.md.
+Codex:      /goal Follow docs/goals/<slug>/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/<slug>/goal.md.
 ```
 
 When that command runs, the PM follows `references/goal-execution.md`.

--- a/goalbuddy/agents/openai.yaml
+++ b/goalbuddy/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Goal Prep"
   short_description: "Prepare GoalBuddy boards before running /goal."
-  default_prompt: "Use goal-prep to run diagnostic intake on my rough or detailed goal. If the goal is vague or improvement-oriented, ask one guided question at a time, surface likely blind spots, and do not create files until intent, proof, scope, and board handling are clear or explicitly defaulted. If it is clear or already planned, prepare or repair goal.md, state.yaml, and notes/, then print the /goal Follow command instead of starting /goal automatically."
+  default_prompt: "Use goal-prep to run diagnostic intake on my rough or detailed goal. If the goal is vague or improvement-oriented, ask one guided question at a time, surface likely blind spots, and do not create files until intent, proof, scope, and board handling are clear or explicitly defaulted. If it is clear or already planned, prepare or repair goal.md, state.yaml, and notes/, then print the Codex /goal and Claude Code /goalbuddy execution commands without starting either automatically."
 policy:
   allow_implicit_invocation: true

--- a/goalbuddy/references/goal-execution.md
+++ b/goalbuddy/references/goal-execution.md
@@ -1,16 +1,17 @@
-# GoalBuddy `/goal` Execution Contract
+# GoalBuddy Execution Contract
 
-This document governs `/goal` runs: the execution mode. Board preparation (`$goal-prep` in Codex, `/goal-prep` in Claude Code) is governed by `SKILL.md` in this skill directory; do not mix the modes. Shared foundations — the intake compiler, slice sizing policy, four primitives, control files, board schema, seed boards, and agent availability states — are defined in `SKILL.md` and apply here unchanged.
+This document governs Codex `/goal` and Claude Code `/goalbuddy` runs: the execution mode. Board preparation (`$goal-prep` in Codex, `/goal-prep` in Claude Code) is governed by `SKILL.md` in this skill directory; do not mix the modes. Shared foundations, including the intake compiler, slice sizing policy, four primitives, control files, board schema, seed boards, and agent availability states, are defined in `SKILL.md` and apply here unchanged.
 
 The run command is:
 
 ```text
-/goal Follow docs/goals/<slug>/goal.md.
+Codex:      /goal Follow docs/goals/<slug>/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/<slug>/goal.md.
 ```
 
-## Direct `/goal` Entry
+## Direct Execution Entry
 
-When `/goal` is invoked with raw user intent instead of an existing `docs/goals/<slug>/goal.md` path, run the Intake Compiler (see `SKILL.md`) before doing implementation work. The PM should not treat raw `/goal` text as an execution plan until it has:
+When `/goal` or `/goalbuddy` is invoked with raw user intent instead of an existing `docs/goals/<slug>/goal.md` path, run the Intake Compiler (see `SKILL.md`) before doing implementation work. The PM should not treat raw command text as an execution plan until it has:
 
 - classified the input shape;
 - preserved any existing plan facts;
@@ -20,7 +21,7 @@ When `/goal` is invoked with raw user intent instead of an existing `docs/goals/
 - selected the safest first active task;
 - either asked the required guided intake question or written `goal.md` and `state.yaml` from a sufficiently clear intake.
 
-When running the Intake Compiler inside a `/goal` run, apply its extraction and diagnostic logic, but skip the prep-turn terminal steps: do not print the `/goal` command and stop. Once the board is written, continue directly into execution.
+When running the Intake Compiler inside an execution run, apply its extraction and diagnostic logic, but skip the prep-turn terminal steps: do not print another execution command and stop. Once the board is written, continue directly into execution.
 
 If the raw input is detailed and already contains a plan, the first board task should validate and operationalize that plan rather than rediscovering from scratch. If the raw input is vague, run the diagnostic intake before creating the board unless the user explicitly says to use defaults. If the raw input is blocked by authority, policy, destructive action, credentials, or ambiguous completion proof, ask one guided question with options or create the smallest safe read-only task only after the user chooses to proceed.
 
@@ -50,9 +51,9 @@ Rules for external dispatch:
 
 ## `/goal` Default Bias: Users Want Work Done
 
-This section applies after the user starts `/goal Follow docs/goals/<slug>/goal.md.` It does not apply to the initial `$goal-prep` board-preparation turn.
+This section applies after the user starts Codex `/goal Follow docs/goals/<slug>/goal.md.` or Claude Code `/goalbuddy Follow docs/goals/<slug>/goal.md.` It does not apply to the initial `$goal-prep` board-preparation turn.
 
-Unless the user explicitly asks for planning only, treat a `/goal` run as a request for work to happen.
+Unless the user explicitly asks for planning only, treat a `/goal` or `/goalbuddy` run as a request for work to happen.
 
 Planning, Scout findings, Judge decisions, and a queued Worker task are not terminal outcomes when the user's original ask is for a working capability, automation, fix, cleanup, or backend/frontend behavior. They are setup for execution.
 
@@ -62,7 +63,7 @@ For execution goals, the default run is continuous:
 Discover enough evidence, choose the largest reversible local work package, implement it, verify it, review only at risk or phase boundaries, then immediately choose and execute the next work package until the full original outcome is complete.
 ```
 
-If the first `/goal` run reaches a Judge decision that names a safe Worker task with `allowed_files`, `verify`, and `stop_if`, the PM should activate that Worker and continue in the same run unless a stop condition applies.
+If the first execution run reaches a Judge decision that names a safe Worker task with `allowed_files`, `verify`, and `stop_if`, the PM should activate that Worker and continue in the same run unless a stop condition applies.
 
 After a verified Worker package, do not mark the thread goal complete merely because that package passed. For broad automation or product goals, continue by reopening or advancing the board to the next safe Worker package until the full owner outcome is complete.
 

--- a/goalbuddy/templates/goal-prompt.txt
+++ b/goalbuddy/templates/goal-prompt.txt
@@ -1,1 +1,2 @@
-/goal Follow docs/goals/<slug>/goal.md.
+Codex: /goal Follow docs/goals/<slug>/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/<slug>/goal.md.

--- a/goalbuddy/templates/goal.md
+++ b/goalbuddy/templates/goal.md
@@ -87,7 +87,8 @@ If this charter and `state.yaml` disagree, `state.yaml` wins for task status, ac
 ## Run Command
 
 ```text
-/goal Follow docs/goals/<slug>/goal.md.
+Codex: /goal Follow docs/goals/<slug>/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/<slug>/goal.md.
 ```
 
 ## PM Loop

--- a/internal/cli/goal-maker.mjs
+++ b/internal/cli/goal-maker.mjs
@@ -24,6 +24,9 @@ const canonicalSkillName = "goal-prep";
 const canonicalSkillDirectory = "goalbuddy";
 const legacyCliName = "goal-maker";
 const legacySkillName = "goal-maker";
+const legacyClaudeGoalCommandHashes = new Set([
+  "586a0839302239858cce64f954666e8690c5ddef036e397adfd9456eed4738e2",
+]);
 const skillSource = join(packageRoot, canonicalSkillDirectory);
 const claudePluginSource = join(packageRoot, "plugins", "goalbuddy");
 const packageInfo = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
@@ -382,6 +385,10 @@ function legacyClaudeCommandPath() {
   return join(claudeHome(), "commands", "goal-prep.md");
 }
 
+function legacyClaudeGoalCommandPath() {
+  return join(claudeHome(), "commands", "goal.md");
+}
+
 function installClaudeSkill({ quiet = false } = {}) {
   const target = claudeSkillRoot();
   if (!existsSync(skillSource)) {
@@ -446,11 +453,11 @@ function installClaudeAgents({ quiet = false } = {}) {
 }
 
 function claudeGoalCommandPath() {
-  return join(claudeHome(), "commands", "goal.md");
+  return join(claudeHome(), "commands", "goalbuddy.md");
 }
 
 function installClaudeGoalCommand({ quiet = false } = {}) {
-  const source = join(claudePluginSource, "commands", "goal.md");
+  const source = join(claudePluginSource, "commands", "goalbuddy.md");
   const target = claudeGoalCommandPath();
   if (!existsSync(source)) return { status: "missing_source", path: target };
   const sourceHash = sha256(readFileSync(source));
@@ -460,6 +467,30 @@ function installClaudeGoalCommand({ quiet = false } = {}) {
   const status = previousHash ? previousHash === sourceHash ? "unchanged" : "updated" : "installed";
   if (!quiet) console.log(`installed ${target}`);
   return { status, path: target };
+}
+
+function cleanupLegacyClaudeGoalCommand({ quiet = false } = {}) {
+  const legacyPath = legacyClaudeGoalCommandPath();
+  if (!existsSync(legacyPath)) {
+    return { removed: false, preserved: false, owned_by_goalbuddy: false, path: legacyPath };
+  }
+
+  const ownedByGoalBuddy = fileIsLegacyGoalBuddyCommand(legacyPath);
+  if (!ownedByGoalBuddy) {
+    return { removed: false, preserved: true, owned_by_goalbuddy: false, path: legacyPath };
+  }
+
+  rmSync(legacyPath, { force: true });
+  if (!quiet) console.log(`removed legacy ${legacyPath} (GoalBuddy now uses /goalbuddy)`);
+  return { removed: true, preserved: false, owned_by_goalbuddy: true, path: legacyPath };
+}
+
+function fileIsLegacyGoalBuddyCommand(path) {
+  try {
+    return legacyClaudeGoalCommandHashes.has(sha256(readFileSync(path)));
+  } catch {
+    return false;
+  }
 }
 
 function cleanupLegacyClaudeCommands({ quiet = false } = {}) {
@@ -483,11 +514,17 @@ async function buildClaudeInstallReport() {
     skill: installClaudeSkill({ quiet }),
     agents: installClaudeAgents({ quiet }),
     goal_command: installClaudeGoalCommand({ quiet }),
+    legacy_goal_command_cleanup: cleanupLegacyClaudeGoalCommand({ quiet }),
     legacy_commands_cleanup: cleanupLegacyClaudeCommands({ quiet }),
     warnings: [],
   };
 
   report.package.previous_version = report.skill.previous_version;
+  if (report.legacy_goal_command_cleanup.preserved) {
+    report.warnings.push(
+      `Preserved ${report.legacy_goal_command_cleanup.path} because it is not GoalBuddy-authored. Claude Code's native /goal may remain shadowed until you rename or remove that file.`,
+    );
+  }
   return report;
 }
 
@@ -558,6 +595,9 @@ function doctorClaude() {
   const legacySkillPresent = existsSync(legacySkillPath);
   const goalCommandPath = claudeGoalCommandPath();
   const goalCommandPresent = existsSync(goalCommandPath);
+  const legacyGoalCommandPath = legacyClaudeGoalCommandPath();
+  const legacyGoalCommandPresent = existsSync(legacyGoalCommandPath);
+  const legacyGoalCommandOwned = legacyGoalCommandPresent && fileIsLegacyGoalBuddyCommand(legacyGoalCommandPath);
 
   console.log(JSON.stringify({
     target: "claude",
@@ -569,13 +609,17 @@ function doctorClaude() {
     stale_agents: staleAgents,
     goal_command_present: goalCommandPresent,
     goal_command_path: goalCommandPath,
+    native_goal_available: !legacyGoalCommandPresent,
+    legacy_goal_command_present: legacyGoalCommandPresent,
+    legacy_goal_command_owned: legacyGoalCommandOwned,
+    legacy_goal_command_path: legacyGoalCommandPath,
     legacy_command_present: legacyCommandPresent,
     legacy_command_path: legacyCommandPath,
     legacy_skill_present: legacySkillPresent,
     legacy_skill_path: legacySkillPath,
   }, null, 2));
 
-  const installOk = installed && missingAgents.length === 0 && staleAgents.length === 0 && goalCommandPresent && !legacyCommandPresent && !legacySkillPresent;
+  const installOk = installed && missingAgents.length === 0 && staleAgents.length === 0 && goalCommandPresent && !legacyGoalCommandPresent && !legacyCommandPresent && !legacySkillPresent;
   process.exit(installOk ? 0 : 1);
 }
 
@@ -589,10 +633,14 @@ function printClaudeInstallReport(report) {
   console.log("");
   console.log(`Skill: ${report.skill.status} at ${report.skill.path}`);
   console.log(`Agents: ${summarizeStatuses(report.agents)}`);
-  console.log(`Command: /goal ${report.goal_command.status} at ${report.goal_command.path}`);
+  console.log(`Command: /goalbuddy ${report.goal_command.status} at ${report.goal_command.path}`);
+  if (report.legacy_goal_command_cleanup?.removed) {
+    console.log(`Removed legacy GoalBuddy command: ${report.legacy_goal_command_cleanup.path}`);
+  }
   if (report.legacy_commands_cleanup?.removed) {
     console.log(`Removed legacy command: ${report.legacy_commands_cleanup.path}`);
   }
+  for (const warning of report.warnings) console.log(`Warning: ${warning}`);
   console.log("");
   console.log("Next:");
   console.log(`  Restart Claude Code, then run: /goal-prep`);
@@ -665,7 +713,7 @@ When invoked through $${legacySkillName}:
 
 1. Tell the user Goal Maker has been rebranded to GoalBuddy.
 2. Show the canonical command: $${canonicalSkillName}.
-3. If the user wants to continue immediately, follow the same workflow as $${canonicalSkillName}: run diagnostic intake, create or repair \`docs/goals/<slug>/goal.md\` and \`state.yaml\`, preserve one active task, and print \`/goal Follow docs/goals/<slug>/goal.md.\` without starting \`/goal\` automatically.
+3. If the user wants to continue immediately, follow the same workflow as $${canonicalSkillName}: run diagnostic intake, create or repair \`docs/goals/<slug>/goal.md\` and \`state.yaml\`, preserve one active task, and print the matching execution commands for Codex (\`/goal Follow docs/goals/<slug>/goal.md.\`) and Claude Code (\`/goalbuddy Follow docs/goals/<slug>/goal.md.\`) without starting either automatically.
 
 This alias has the same invocation boundary as \`$${canonicalSkillName}\`: prepare the board only. Do not use or refresh named skills, inspect implementation files, browse references, research, generate assets, or perform the requested work until the user starts the printed \`/goal\` command.
 `;
@@ -1256,13 +1304,15 @@ function initGoal() {
     .replaceAll("<slug>", slug));
 
   const runCommand = `/goal Follow docs/goals/${slug}/goal.md.`;
+  const claudeRunCommand = `/goalbuddy Follow docs/goals/${slug}/goal.md.`;
   if (hasFlag("--json")) {
-    printJson({ created: goalDir, slug, title, run_command: runCommand });
+    printJson({ created: goalDir, slug, title, run_command: runCommand, claude_run_command: claudeRunCommand });
     return;
   }
   console.log(`Created GoalBuddy board: docs/goals/${slug}/`);
   console.log("Next: refine the charter and intake with $goal-prep (Codex) or /goal-prep (Claude Code),");
-  console.log(`or start execution: ${runCommand}`);
+  console.log(`or start execution in Codex: ${runCommand}`);
+  console.log(`or start execution in Claude Code: ${claudeRunCommand}`);
 }
 
 function receiptCli() {
@@ -1319,8 +1369,10 @@ async function resume() {
     console.log(`${board.title} — ${board.status} (${board.path})`);
     if (board.active_task) {
       console.log(`  Active task: ${board.active_task.id} (${board.active_task.type}) ${board.active_task.objective}`);
-      console.log("  Resume in any harness (Codex or Claude Code):");
+      console.log("  Resume in Codex:");
       console.log(`    ${board.run_command}`);
+      console.log("  Resume in Claude Code:");
+      console.log(`    ${board.claude_run_command}`);
       console.log(`  Full task prompt: npx ${canonicalCliName} prompt ${board.path}`);
     } else {
       console.log("  No active task.");
@@ -1351,9 +1403,10 @@ function describeBoard(goalDir, createBoardPayload) {
       status: payload.goal.status,
       active_task: activeTask ? { id: activeTask.id, type: activeTask.type, objective: activeTask.objective } : null,
       run_command: `/goal Follow ${path}/goal.md.`,
+      claude_run_command: `/goalbuddy Follow ${path}/goal.md.`,
     };
   } catch (error) {
-    return { path, slug: "", title: path, status: "unreadable", active_task: null, run_command: "", error: error.message };
+    return { path, slug: "", title: path, status: "unreadable", active_task: null, run_command: "", claude_run_command: "", error: error.message };
   }
 }
 
@@ -1565,9 +1618,14 @@ function printEverywhereInstallReport(report) {
   } else if (report.claude) {
     console.log(`Claude Code: skill ${report.claude.skill.status} at ${report.claude.skill.path}`);
     console.log(`Claude Code agents: ${summarizeStatuses(report.claude.agents)}`);
+    console.log(`Claude Code command: /goalbuddy ${report.claude.goal_command.status} at ${report.claude.goal_command.path}`);
+    if (report.claude.legacy_goal_command_cleanup?.removed) {
+      console.log(`Claude Code: removed legacy GoalBuddy command at ${report.claude.legacy_goal_command_cleanup.path}`);
+    }
     if (report.claude.legacy_commands_cleanup?.removed) {
       console.log(`Claude Code: removed legacy command at ${report.claude.legacy_commands_cleanup.path}`);
     }
+    for (const warning of report.claude.warnings || []) console.log(`Claude Code warning: ${warning}`);
   }
 
   if (report.errors.length) {

--- a/internal/test/goal-maker-cli.test.mjs
+++ b/internal/test/goal-maker-cli.test.mjs
@@ -1167,6 +1167,8 @@ test("default command installs Codex and Claude Code when both homes are provide
     assert.equal(existsSync(join(codexHome, "config.toml")), true);
     assert.equal(existsSync(join(claudeHome, "skills", "goal-prep", "SKILL.md")), true);
     assert.equal(existsSync(join(claudeHome, "agents", "goal-worker.md")), true);
+    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), true);
+    assert.equal(existsSync(join(claudeHome, "commands", "goal.md")), false);
     assert.equal(existsSync(join(claudeHome, "commands", "goal-prep.md")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -1382,19 +1384,70 @@ test("installs the Claude skill as goal-prep and migrates the legacy directory",
   }
 });
 
-test("installs the /goal command for Claude Code", () => {
+test("installs /goalbuddy without shadowing Claude Code's native /goal", () => {
   const root = mkdtempSync(join(tmpdir(), "goalbuddy-goal-command-"));
   try {
     const claudeHome = join(root, "claude");
     const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"]);
     assert.equal(result.status, 0, result.stderr);
-    const command = readFileSync(join(claudeHome, "commands", "goal.md"), "utf8");
+    const command = readFileSync(join(claudeHome, "commands", "goalbuddy.md"), "utf8");
     assert.match(command, /GoalBuddy/);
     assert.match(command, /state\.yaml/);
+    assert.equal(existsSync(join(claudeHome, "commands", "goal.md")), false);
 
     const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome]);
     assert.equal(doctor.status, 0, doctor.stderr || doctor.stdout);
-    assert.equal(JSON.parse(doctor.stdout).goal_command_present, true);
+    const report = JSON.parse(doctor.stdout);
+    assert.equal(report.goal_command_present, true);
+    assert.equal(report.native_goal_available, true);
+    assert.equal(report.legacy_goal_command_present, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("install removes an old GoalBuddy-owned /goal command", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-goal-command-migration-"));
+  try {
+    const claudeHome = join(root, "claude");
+    const legacyCommand = join(claudeHome, "commands", "goal.md");
+    mkdirSync(join(claudeHome, "commands"), { recursive: true });
+    const legacyBody = readFileSync("plugins/goalbuddy/commands/goalbuddy.md", "utf8")
+      .replace("Run the GoalBuddy execution loop.\n", "Run the GoalBuddy `/goal` execution loop.\n");
+    writeFileSync(legacyCommand, legacyBody);
+
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"]);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.legacy_goal_command_cleanup.removed, true);
+    assert.equal(existsSync(legacyCommand), false);
+    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("install preserves a user-authored /goal command and doctor reports the collision", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-user-goal-command-"));
+  try {
+    const claudeHome = join(root, "claude");
+    const legacyCommand = join(claudeHome, "commands", "goal.md");
+    mkdirSync(join(claudeHome, "commands"), { recursive: true });
+    writeFileSync(legacyCommand, "My private GoalBuddy helper.\n");
+
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"]);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.legacy_goal_command_cleanup.preserved, true);
+    assert.match(report.warnings.join("\n"), /native \/goal may remain shadowed/);
+    assert.equal(readFileSync(legacyCommand, "utf8"), "My private GoalBuddy helper.\n");
+
+    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome]);
+    assert.equal(doctor.status, 1, doctor.stderr || doctor.stdout);
+    const doctorReport = JSON.parse(doctor.stdout);
+    assert.equal(doctorReport.native_goal_available, false);
+    assert.equal(doctorReport.legacy_goal_command_present, true);
+    assert.equal(doctorReport.legacy_goal_command_owned, false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1475,8 +1528,10 @@ test("resume lists boards and prints the handoff command for active goals", () =
     assert.match(result.stdout, /one goal/);
     assert.match(result.stdout, /two goal/);
     assert.match(result.stdout, /T001 \(worker\) Fix the widget in one\./);
-    assert.match(result.stdout, /Resume in any harness \(Codex or Claude Code\)/);
+    assert.match(result.stdout, /Resume in Codex/);
+    assert.match(result.stdout, /Resume in Claude Code/);
     assert.match(result.stdout, /\/goal Follow docs\/goals\/one\/goal\.md\./);
+    assert.match(result.stdout, /\/goalbuddy Follow docs\/goals\/one\/goal\.md\./);
     assert.doesNotMatch(result.stdout, /\/goal Follow docs\/goals\/two\/goal\.md\./);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -1495,6 +1550,7 @@ test("resume --json returns structured boards", () => {
     assert.equal(report.boards[0].status, "active");
     assert.equal(report.boards[0].active_task.id, "T001");
     assert.equal(report.boards[0].run_command, "/goal Follow docs/goals/one/goal.md.");
+    assert.equal(report.boards[0].claude_run_command, "/goalbuddy Follow docs/goals/one/goal.md.");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1536,6 +1592,7 @@ test("init scaffolds a working board from the bundled templates", () => {
     const report = JSON.parse(created.stdout);
     assert.equal(report.slug, "ship-widgets");
     assert.equal(report.run_command, "/goal Follow docs/goals/ship-widgets/goal.md.");
+    assert.equal(report.claude_run_command, "/goalbuddy Follow docs/goals/ship-widgets/goal.md.");
     const state = readFileSync(join(root, "docs", "goals", "ship-widgets", "state.yaml"), "utf8");
     assert.match(state, /version: 2/);
     assert.match(state, /slug: "ship-widgets"/);

--- a/internal/test/goalbuddy-skill-policy.test.mjs
+++ b/internal/test/goalbuddy-skill-policy.test.mjs
@@ -29,7 +29,8 @@ function fakeCodexBin(root) {
 
 test("Goal Prep invocation boundary keeps $goal-prep prepare-only", () => {
   for (const text of [canonicalSkill, pluginSkill]) {
-    assert.match(text, /\$goal-prep`: prepare intake, `goal\.md`, `state\.yaml`, and the starter `\/goal` command, then stop/);
+    assert.match(text, /\$goal-prep` or `\/goal-prep`: prepare intake, `goal\.md`, `state\.yaml`, and the starter execution commands, then stop/);
+    assert.match(text, /Claude Code `\/goalbuddy Follow docs\/goals\/<slug>\/goal\.md\.`/);
     assert.match(text, /During a `\$goal-prep` turn, do not perform the user's requested work/);
     assert.match(text, /Do not refresh or load named skills/);
     assert.match(text, /Do not load that skill, browse that repo, or generate those assets during `\$goal-prep`/);
@@ -60,14 +61,14 @@ test("Goal Prep invocation boundary keeps $goal-prep prepare-only", () => {
   }
 });
 
-test("the execution contract carries the /goal runtime rules", () => {
+test("the execution contract carries the harness-specific runtime rules", () => {
   for (const text of [canonicalExecution, pluginExecution]) {
-    assert.match(text, /governs `\/goal` runs/);
+    assert.match(text, /governs Codex `\/goal` and Claude Code `\/goalbuddy` runs/);
     assert.match(text, /node <skill-path>\/scripts\/render-task-prompt\.mjs docs\/goals\/<slug>/);
     assert.match(text, /node <skill-path>\/scripts\/parallel-plan\.mjs docs\/goals\/<slug>/);
     assert.match(text, /Operator Escalation/);
     assert.match(text, /ask the operator one concise question before creating the external artifact/);
-    assert.match(text, /This section applies after the user starts `\/goal Follow docs\/goals\/<slug>\/goal\.md\.`/);
+    assert.match(text, /This section applies after the user starts Codex `\/goal Follow docs\/goals\/<slug>\/goal\.md\.` or Claude Code `\/goalbuddy Follow docs\/goals\/<slug>\/goal\.md\.`/);
     assert.match(text, /exact human approval phrase is the only remaining blocker/);
     assert.match(text, /waiting_for_user_approval: true/);
     assert.match(text, /required_reply: "<exact phrase>"/);

--- a/internal/test/package-files.test.mjs
+++ b/internal/test/package-files.test.mjs
@@ -61,10 +61,12 @@ test("the packed npm artifact installs the Claude contract and role agents", () 
       report.agents.map((agent) => agent.file).sort(),
       ["goal-judge.md", "goal-scout.md", "goal-worker.md"],
     );
+    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), true);
+    assert.equal(existsSync(join(claudeHome, "commands", "goal.md")), false);
 
     const installedContract = join(claudeHome, "skills", "goal-prep", "references", "goal-execution.md");
     assert.equal(existsSync(installedContract), true);
-    assert.match(readFileSync(installedContract, "utf8"), /governs `\/goal` runs/);
+    assert.match(readFileSync(installedContract, "utf8"), /governs Codex `\/goal` and Claude Code `\/goalbuddy` runs/);
     for (const file of ["goal-judge.md", "goal-scout.md", "goal-worker.md"]) {
       assert.equal(existsSync(join(claudeHome, "agents", file)), true);
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "goalbuddy",
-  "version": "0.4.2",
-  "description": "A /goal operating loop for Codex and Claude Code: goal oracles, local boards, receipts, and verification.",
+  "version": "0.4.3",
+  "description": "A goal operating loop for Codex and Claude Code: goal oracles, local boards, receipts, and verification.",
   "type": "module",
   "bin": {
     "goalbuddy": "internal/cli/goal-maker.mjs",

--- a/plugins/goalbuddy/.claude-plugin/plugin.json
+++ b/plugins/goalbuddy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "goalbuddy",
-  "version": "0.4.2",
-  "description": "Turn broad Codex and Claude Code work into pressured /goal runs with oracles, local boards, receipts, and verification.",
+  "version": "0.4.3",
+  "description": "Turn broad Codex and Claude Code work into pressured goal runs with oracles, local boards, receipts, and verification.",
   "author": {
     "name": "tolibear",
     "email": "support@tolibear.com",

--- a/plugins/goalbuddy/.codex-plugin/plugin.json
+++ b/plugins/goalbuddy/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "goalbuddy",
-  "version": "0.4.2",
-  "description": "Turn broad Codex and Claude Code work into pressured /goal runs with oracles, local boards, receipts, and verification.",
+  "version": "0.4.3",
+  "description": "Turn broad Codex and Claude Code work into pressured goal runs with oracles, local boards, receipts, and verification.",
   "author": {
     "name": "tolibear",
     "email": "support@tolibear.com",

--- a/plugins/goalbuddy/README.md
+++ b/plugins/goalbuddy/README.md
@@ -2,15 +2,16 @@
 
 GoalBuddy packages the canonical `goal-prep` skill as a plugin so teams can install the reusable workflow in **Codex** and **Claude Code**, while keeping the npm CLI for local setup, doctor checks, and the built-in local board surface.
 
-Version 0.3.9 keeps the Goalmaxxed core and hardens marketplace installs, local board rendering, and PM runtime guidance for approval waits and board-health checks.
+Version 0.4.3 preserves Claude Code's native `/goal` command and installs GoalBuddy execution as `/goalbuddy`.
 
 ## What It Contains
 
 - `.codex-plugin/plugin.json`: Codex plugin manifest and Codex UI copy.
 - `.claude-plugin/plugin.json`: Claude Code plugin manifest.
-- `skills/goalbuddy/`: the installable GoalBuddy skill payload (shared by both platforms).
+- `skills/goal-prep/`: the installable GoalBuddy skill payload (shared by both platforms).
 - `agents/`: Claude Code subagent definitions (`goal-scout.md`, `goal-judge.md`, `goal-worker.md`).
-- `skills/goalbuddy/SKILL.md`: canonical `$goal-prep` / `/goal-prep` entry point.
+- `commands/goalbuddy.md`: Claude Code's GoalBuddy execution command, kept separate from native `/goal`.
+- `skills/goal-prep/SKILL.md`: canonical `$goal-prep` / `/goal-prep` entry point.
 - `assets/goalbuddy-icon.svg`: lightweight plugin icon.
 
 ## Local Testing
@@ -29,7 +30,7 @@ npx goalbuddy check-update
 npx goalbuddy
 ```
 
-This installs and enables the native Codex plugin in `~/.codex/`, then installs the GoalBuddy skill and Scout/Judge/Worker subagents into `~/.claude/`. The skill surfaces `/goal-prep` in Claude Code.
+This installs and enables the native Codex plugin in `~/.codex/`, then installs the GoalBuddy skill, `/goalbuddy` command, and Scout/Judge/Worker subagents into `~/.claude/`. The skill surfaces `/goal-prep` in Claude Code.
 
 ## Install One Target
 
@@ -43,6 +44,8 @@ This installs the GoalBuddy skill and the three Scout/Judge/Worker subagents int
 ```text
 /goal-prep
 ```
+
+After Goal Prep creates a board, start it with Codex `/goal` or Claude Code `/goalbuddy`, as printed by the tool.
 
 Or install the npm package globally:
 

--- a/plugins/goalbuddy/commands/goalbuddy.md
+++ b/plugins/goalbuddy/commands/goalbuddy.md
@@ -2,7 +2,7 @@
 description: Run the GoalBuddy execution loop against a prepared goal board
 ---
 
-Run the GoalBuddy `/goal` execution loop.
+Run the GoalBuddy execution loop.
 
 Goal: $ARGUMENTS
 

--- a/plugins/goalbuddy/skills/goal-prep/SKILL.md
+++ b/plugins/goalbuddy/skills/goal-prep/SKILL.md
@@ -5,7 +5,7 @@ description: Goal Prep for GoalBuddy. Use for broad, long-running, stalled, vagu
 
 # Goal Prep
 
-`$goal-prep` (Codex) or `/goal-prep` (Claude Code) prepares a GoalBuddy board. It does not start `/goal` automatically, but the board and starter `/goal` command must be shaped so the next run continues into safe execution by default.
+`$goal-prep` (Codex) or `/goal-prep` (Claude Code) prepares a GoalBuddy board. It does not start execution automatically, but the board and harness-specific starter command must be shaped so the next run continues into safe execution by default.
 
 GoalBuddy is for autonomous, long-running Codex or Claude Code work where the PM thread may need to discover the work, define tasks, sequence them, delegate them, execute them, verify them, and keep going without the human decomposing every step.
 
@@ -27,12 +27,12 @@ No oracle, no serious goal. A goal oracle is the observable signal that tells th
 
 There are two different modes:
 
-- `$goal-prep`: prepare intake, `goal.md`, `state.yaml`, and the starter `/goal` command, then stop.
-- `/goal Follow docs/goals/<slug>/goal.md.`: execute the board, including Scout/Judge/Worker work.
+- `$goal-prep` or `/goal-prep`: prepare intake, `goal.md`, `state.yaml`, and the starter execution commands, then stop.
+- Codex `/goal Follow docs/goals/<slug>/goal.md.` or Claude Code `/goalbuddy Follow docs/goals/<slug>/goal.md.`: execute the board, including Scout/Judge/Worker work.
 
 This boundary is strict. `$goal-prep` is not a lightweight `/goal`; it is a board compiler.
 
-This document is the prep-mode contract plus the shared board model. The `/goal` execution contract lives in `references/goal-execution.md` next to this file; read it at the start of every `/goal` run. If it cannot be read, these execution invariants still hold: `state.yaml` is board truth; exactly one active task unless disjoint write scopes are proven; Scout and Judge tasks are read-only; Worker tasks write only inside `allowed_files` and run their `verify` commands; every completed, blocked, or escalated task gets a receipt; the goal completes only through a final Judge or PM audit that maps receipts and verification back to the original outcome (recording `full_outcome_complete: true` for continuous execution goals).
+This document is the prep-mode contract plus the shared board model. The execution contract lives in `references/goal-execution.md` next to this file; read it at the start of every Codex `/goal` or Claude Code `/goalbuddy` run. If it cannot be read, these execution invariants still hold: `state.yaml` is board truth; exactly one active task unless disjoint write scopes are proven; Scout and Judge tasks are read-only; Worker tasks write only inside `allowed_files` and run their `verify` commands; every completed, blocked, or escalated task gets a receipt; the goal completes only through a final Judge or PM audit that maps receipts and verification back to the original outcome (recording `full_outcome_complete: true` for continuous execution goals).
 
 During a `$goal-prep` turn, do not perform the user's requested work, even if the work looks read-only, preparatory, or obviously useful. Do not refresh or load named skills, inspect implementation files, browse reference repos, research design inspiration, generate design plans, generate images/assets, run app-specific checks, or edit product files. Put those actions into Scout, Judge, Worker, or PM tasks for the later `/goal` run.
 
@@ -44,8 +44,8 @@ Allowed `$goal-prep` actions:
 - create and open the built-in local GoalBuddy board surface for the goal unless the user opts out;
 - optionally run the GoalBuddy board checker against that `state.yaml`;
 - verify GoalBuddy agent availability, if this can be done without touching implementation work, and record `installed`, `bundled_not_installed`, `missing`, or `unknown` truthfully;
-- print exactly `/goal Follow docs/goals/<slug>/goal.md.`;
-- ask whether to start `/goal`, refine the board, or stop.
+- print both exact execution commands: Codex `/goal Follow docs/goals/<slug>/goal.md.` and Claude Code `/goalbuddy Follow docs/goals/<slug>/goal.md.`;
+- ask whether to start execution, refine the board, or stop.
 
 If the prompt names another skill or tool, such as "use the taste skill", "refresh the taste skill", "look at this repo", "use browser", or "generate assets", record that requirement in the charter and seed tasks. Do not load that skill, browse that repo, or generate those assets during `$goal-prep`.
 
@@ -175,7 +175,7 @@ Do:
 - seed a role-tagged task board that matches the input shape;
 - make the first active task safe;
 - verify Scout, Worker, and Judge agent availability or record an explicit truthful state;
-- print the exact command `/goal Follow docs/goals/<slug>/goal.md.`;
+- print the exact Codex command `/goal Follow docs/goals/<slug>/goal.md.` and Claude Code command `/goalbuddy Follow docs/goals/<slug>/goal.md.`;
 - ask whether to start now, refine `goal.md`, or stop.
 
 Do not:
@@ -380,10 +380,11 @@ A task's `assignee` determines the agent. The task card is the order. The receip
 
 Only the main `/goal` PM may choose the active task, update the board, mark tasks done, or mark the goal complete. The PM thinking policy and the execution quality commands (including the subagent dispatch rules) live in `references/goal-execution.md`.
 
-## Default `/goal` Shape
+## Default Execution Shape
 
 ```text
-/goal Follow docs/goals/<slug>/goal.md.
+Codex:      /goal Follow docs/goals/<slug>/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/<slug>/goal.md.
 ```
 
 When that command runs, the PM follows `references/goal-execution.md`.

--- a/plugins/goalbuddy/skills/goal-prep/agents/openai.yaml
+++ b/plugins/goalbuddy/skills/goal-prep/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Goal Prep"
   short_description: "Prepare GoalBuddy boards before running /goal."
-  default_prompt: "Use goal-prep to run diagnostic intake on my rough or detailed goal. If the goal is vague or improvement-oriented, ask one guided question at a time, surface likely blind spots, and do not create files until intent, proof, scope, and board handling are clear or explicitly defaulted. If it is clear or already planned, prepare or repair goal.md, state.yaml, and notes/, then print the /goal Follow command instead of starting /goal automatically."
+  default_prompt: "Use goal-prep to run diagnostic intake on my rough or detailed goal. If the goal is vague or improvement-oriented, ask one guided question at a time, surface likely blind spots, and do not create files until intent, proof, scope, and board handling are clear or explicitly defaulted. If it is clear or already planned, prepare or repair goal.md, state.yaml, and notes/, then print the Codex /goal and Claude Code /goalbuddy execution commands without starting either automatically."
 policy:
   allow_implicit_invocation: true

--- a/plugins/goalbuddy/skills/goal-prep/references/goal-execution.md
+++ b/plugins/goalbuddy/skills/goal-prep/references/goal-execution.md
@@ -1,16 +1,17 @@
-# GoalBuddy `/goal` Execution Contract
+# GoalBuddy Execution Contract
 
-This document governs `/goal` runs: the execution mode. Board preparation (`$goal-prep` in Codex, `/goal-prep` in Claude Code) is governed by `SKILL.md` in this skill directory; do not mix the modes. Shared foundations — the intake compiler, slice sizing policy, four primitives, control files, board schema, seed boards, and agent availability states — are defined in `SKILL.md` and apply here unchanged.
+This document governs Codex `/goal` and Claude Code `/goalbuddy` runs: the execution mode. Board preparation (`$goal-prep` in Codex, `/goal-prep` in Claude Code) is governed by `SKILL.md` in this skill directory; do not mix the modes. Shared foundations, including the intake compiler, slice sizing policy, four primitives, control files, board schema, seed boards, and agent availability states, are defined in `SKILL.md` and apply here unchanged.
 
 The run command is:
 
 ```text
-/goal Follow docs/goals/<slug>/goal.md.
+Codex:      /goal Follow docs/goals/<slug>/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/<slug>/goal.md.
 ```
 
-## Direct `/goal` Entry
+## Direct Execution Entry
 
-When `/goal` is invoked with raw user intent instead of an existing `docs/goals/<slug>/goal.md` path, run the Intake Compiler (see `SKILL.md`) before doing implementation work. The PM should not treat raw `/goal` text as an execution plan until it has:
+When `/goal` or `/goalbuddy` is invoked with raw user intent instead of an existing `docs/goals/<slug>/goal.md` path, run the Intake Compiler (see `SKILL.md`) before doing implementation work. The PM should not treat raw command text as an execution plan until it has:
 
 - classified the input shape;
 - preserved any existing plan facts;
@@ -20,7 +21,7 @@ When `/goal` is invoked with raw user intent instead of an existing `docs/goals/
 - selected the safest first active task;
 - either asked the required guided intake question or written `goal.md` and `state.yaml` from a sufficiently clear intake.
 
-When running the Intake Compiler inside a `/goal` run, apply its extraction and diagnostic logic, but skip the prep-turn terminal steps: do not print the `/goal` command and stop. Once the board is written, continue directly into execution.
+When running the Intake Compiler inside an execution run, apply its extraction and diagnostic logic, but skip the prep-turn terminal steps: do not print another execution command and stop. Once the board is written, continue directly into execution.
 
 If the raw input is detailed and already contains a plan, the first board task should validate and operationalize that plan rather than rediscovering from scratch. If the raw input is vague, run the diagnostic intake before creating the board unless the user explicitly says to use defaults. If the raw input is blocked by authority, policy, destructive action, credentials, or ambiguous completion proof, ask one guided question with options or create the smallest safe read-only task only after the user chooses to proceed.
 
@@ -50,9 +51,9 @@ Rules for external dispatch:
 
 ## `/goal` Default Bias: Users Want Work Done
 
-This section applies after the user starts `/goal Follow docs/goals/<slug>/goal.md.` It does not apply to the initial `$goal-prep` board-preparation turn.
+This section applies after the user starts Codex `/goal Follow docs/goals/<slug>/goal.md.` or Claude Code `/goalbuddy Follow docs/goals/<slug>/goal.md.` It does not apply to the initial `$goal-prep` board-preparation turn.
 
-Unless the user explicitly asks for planning only, treat a `/goal` run as a request for work to happen.
+Unless the user explicitly asks for planning only, treat a `/goal` or `/goalbuddy` run as a request for work to happen.
 
 Planning, Scout findings, Judge decisions, and a queued Worker task are not terminal outcomes when the user's original ask is for a working capability, automation, fix, cleanup, or backend/frontend behavior. They are setup for execution.
 
@@ -62,7 +63,7 @@ For execution goals, the default run is continuous:
 Discover enough evidence, choose the largest reversible local work package, implement it, verify it, review only at risk or phase boundaries, then immediately choose and execute the next work package until the full original outcome is complete.
 ```
 
-If the first `/goal` run reaches a Judge decision that names a safe Worker task with `allowed_files`, `verify`, and `stop_if`, the PM should activate that Worker and continue in the same run unless a stop condition applies.
+If the first execution run reaches a Judge decision that names a safe Worker task with `allowed_files`, `verify`, and `stop_if`, the PM should activate that Worker and continue in the same run unless a stop condition applies.
 
 After a verified Worker package, do not mark the thread goal complete merely because that package passed. For broad automation or product goals, continue by reopening or advancing the board to the next safe Worker package until the full owner outcome is complete.
 

--- a/plugins/goalbuddy/skills/goal-prep/templates/goal-prompt.txt
+++ b/plugins/goalbuddy/skills/goal-prep/templates/goal-prompt.txt
@@ -1,1 +1,2 @@
-/goal Follow docs/goals/<slug>/goal.md.
+Codex: /goal Follow docs/goals/<slug>/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/<slug>/goal.md.

--- a/plugins/goalbuddy/skills/goal-prep/templates/goal.md
+++ b/plugins/goalbuddy/skills/goal-prep/templates/goal.md
@@ -87,7 +87,8 @@ If this charter and `state.yaml` disagree, `state.yaml` wins for task status, ac
 ## Run Command
 
 ```text
-/goal Follow docs/goals/<slug>/goal.md.
+Codex: /goal Follow docs/goals/<slug>/goal.md.
+Claude Code: /goalbuddy Follow docs/goals/<slug>/goal.md.
 ```
 
 ## PM Loop


### PR DESCRIPTION
## Summary

- install GoalBuddy execution as `/goalbuddy` in Claude Code so native `/goal` remains available
- migrate the old GoalBuddy-owned `~/.claude/commands/goal.md` by exact known-file hash
- preserve user-authored `goal.md` files and report the remaining collision through install warnings and `doctor`
- print harness-specific continuation commands from Goal Prep, `init`, and `resume`
- prepare the 0.4.3 patch release and documentation

## Safety

The migration deletes only the exact GoalBuddy 0.4.0-0.4.2 command payload. Any modified or user-authored `goal.md` is preserved. The new command is installed before cleanup runs.

## Verification

- `npm run check` (132 tests passed)
- `npm run pack:dry-run`
- `node internal/cli/check-publish-version.mjs`
- live reproduction on Claude Code 2.1.222 confirmed GoalBuddy 0.4.2 shadowed native `/goal`

Fixes #40
