### PR TITLE
fix: Warn when boards become process-heavy and micro-sliced

### DIFF
--- a/goalbuddy/SKILL.md
+++ b/goalbuddy/SKILL.md
@@ -206,6 +206,8 @@ After two tiny tasks in a row, PM or Judge should reorient the board. If a demo 
 
 Tiny tasks are allowed when the failure is isolated, the risk is high, the scope is unknown, or the tiny task unlocks a larger slice. Tiny tasks are bad when they keep happening, do not change behavior, only add wrappers/contracts/proof files, or avoid the real milestone.
 
+One task normally carries its slice end to end: implementation, targeted tests, CI or readback, and proof, whenever authority and risk stay the same. Do not split planning, individual checks, CI, readback, or receipt handling into separate cards; that duplicates native Goal and PR/CI evidence instead of reducing risk. Reserve Scout for material uncertainty and Judge for phase, risk, rejected-verification, or final-completion boundaries.
+
 ## When To Use
 
 Use this skill for goals that are broad, multi-hour, ambiguous, high-risk, already planned, already stale, already red, or likely to need Scout/Judge/Worker delegation.
@@ -300,6 +302,8 @@ The PM owns the board. Scout, Judge, and Worker return receipts; they do not sel
 ## Seed Boards
 
 If the goal is vague, the first active task is Scout, but the seeded board should still lead toward execution. Queue Judge selection, a bounded Worker slot, and a final audit.
+
+Seed roughly 3-7 outcome-sized phases, not a long chain of micro-steps. Duration alone is not a reason to use GoalBuddy; a long single-owner sequential run may fit native Goal better. When an existing board has grown process-heavy, preserve completed history and receipts unchanged and consolidate only the future work into outcome-sized phases.
 
 If the user provides an existing plan, do not ignore it and do not execute it blindly. Preserve the plan in `goal.intake.existing_plan_facts`, make the first active task PM or Judge validation, and queue Worker slices only after the plan is checked for evidence, risk, allowed files, verification, and stop conditions.
 

--- a/goalbuddy/references/goal-execution.md
+++ b/goalbuddy/references/goal-execution.md
@@ -225,6 +225,8 @@ If a local board server is running, compare `state.yaml` with `http://127.0.0.1:
 
 Board-health work should verify these truths: `active_task` matches live task status, done and blocked tasks have receipts, human-blocked work is in the blocked column, future work stays queued, and the live board/API reflects `state.yaml`.
 
+The checker and the task-prompt renderer also emit advisory process-heavy warnings. They never fail an otherwise valid board, and they never ask to rewrite completed history or receipts; only future work should be consolidated into roughly 3-7 outcome-sized phases. The thresholds live in `PROCESS_HEAVY_THRESHOLDS` in `scripts/check-goal-state.mjs` (mirrored in `scripts/render-task-prompt.mjs`) and warn when: unfinished cards reach 12 or more, including on blocked boards with no active task; PM/Judge/Scout cards exceed twice the Worker cards once the board has 12 or more cards; or 4 or more consecutive dispatched process-only cards follow the last Worker card without a new verifiable capability.
+
 ## Operator Escalation
 
 When Scout, Judge, Worker, or PM discovers a problem, improvement opportunity, product suggestion, follow-up repair, or tool limitation that should not be fixed inside the current active task, do not let it disappear in chat.

--- a/goalbuddy/scripts/check-goal-state.mjs
+++ b/goalbuddy/scripts/check-goal-state.mjs
@@ -452,6 +452,7 @@ for (const task of tasks) {
 }
 
 warnings.push(...microSliceWarnings(tasks, activeTask, goalStatus));
+warnings.push(...processHeavyWarnings(tasks, activeTask, goalStatus));
 
 function isTerminalApprovalWait(tasks, activeTasks, activeTask) {
   if (goalStatus !== "blocked") return false;
@@ -588,6 +589,49 @@ function isTinyTask(task) {
   const text = [task.objective, task.raw, task.receipt?.raw].join(" ").toLowerCase();
   if (/collapsed|batch|package|tranche|vertical slice|milestone/.test(text)) return false;
   return /\b(tiny|narrow|single helper|one helper|projection helper|projection function|contract file|read-only proof|doc note|validator|validation wrapper|pure helper|caller-input)\b/.test(text);
+}
+
+// Process-heavy board heuristics. Advisory only: they never fail a board and never ask to
+// rewrite completed history; only future work should be consolidated. Tuning knobs:
+// - largeUnfinished: unfinished (non-done) cards at/above this count warn, including on
+//   blocked boards with no active task.
+// - ratioMinTasks / processToWorkerRatio: once the board has ratioMinTasks cards, warn when
+//   process cards (pm + judge + scout) exceed processToWorkerRatio x Worker cards.
+// - processRun: warn after this many consecutive dispatched (non-queued) process cards
+//   since the last Worker card, because repeated planning/audit adds no new capability.
+// Keep this function byte-identical to processHeavyWarnings in scripts/render-task-prompt.mjs
+// so warning conditions and messages stay in sync across the checker and the prompt renderer.
+function processHeavyWarnings(tasks, activeTaskId, goalStatus) {
+  const PROCESS_HEAVY_THRESHOLDS = {
+    largeUnfinished: 12,
+    ratioMinTasks: 12,
+    processToWorkerRatio: 2,
+    processRun: 4,
+  };
+  const { largeUnfinished, ratioMinTasks, processToWorkerRatio, processRun } = PROCESS_HEAVY_THRESHOLDS;
+  const found = [];
+  const consolidate = "Preserve completed history and consolidate only future work into roughly 3-7 outcome-sized phases. Duration alone is not a reason to use GoalBuddy; native Goal may fit a long single-owner sequential run better.";
+  const isWorker = (task) => task.type?.toLowerCase() === "worker";
+  const unfinished = tasks.filter((task) => task.status !== "done");
+  if (unfinished.length >= largeUnfinished) {
+    const stalled = goalStatus !== "active" && !activeTaskId ? " on a blocked board with no active task" : "";
+    found.push(`Board is process-heavy: ${unfinished.length} unfinished tasks${stalled}. ${consolidate}`);
+  }
+  const workerCount = tasks.filter(isWorker).length;
+  const processCount = tasks.length - workerCount;
+  if (tasks.length >= ratioMinTasks && processCount > processToWorkerRatio * Math.max(workerCount, 1)) {
+    found.push(`Board is process-heavy: ${processCount} PM/Judge/Scout tasks vs ${workerCount} Worker tasks. One task should normally include implementation, targeted tests, CI/readback, and proof when authority and risk stay the same. Reserve Scout for material uncertainty and Judge for phase, risk, rejected-verification, or final boundaries.`);
+  }
+  const dispatched = tasks.filter((task) => task.status !== "queued");
+  let run = 0;
+  for (let index = dispatched.length - 1; index >= 0; index -= 1) {
+    if (isWorker(dispatched[index])) break;
+    run += 1;
+  }
+  if (run >= processRun) {
+    found.push(`Board is process-heavy: ${run} consecutive planning, audit, or process-only tasks since the last Worker task added no new verifiable capability. ${consolidate}`);
+  }
+  return found;
 }
 
 function matchesAllowedFile(file, allowedFiles) {

--- a/goalbuddy/scripts/check-goal-state.mjs
+++ b/goalbuddy/scripts/check-goal-state.mjs
@@ -591,16 +591,12 @@ function isTinyTask(task) {
   return /\b(tiny|narrow|single helper|one helper|projection helper|projection function|contract file|read-only proof|doc note|validator|validation wrapper|pure helper|caller-input)\b/.test(text);
 }
 
-// Process-heavy board heuristics. Advisory only: they never fail a board and never ask to
-// rewrite completed history; only future work should be consolidated. Tuning knobs:
-// - largeUnfinished: unfinished (non-done) cards at/above this count warn, including on
-//   blocked boards with no active task.
-// - ratioMinTasks / processToWorkerRatio: once the board has ratioMinTasks cards, warn when
-//   process cards (pm + judge + scout) exceed processToWorkerRatio x Worker cards.
-// - processRun: warn after this many consecutive dispatched (non-queued) process cards
-//   since the last Worker card, because repeated planning/audit adds no new capability.
-// Keep this function byte-identical to processHeavyWarnings in scripts/render-task-prompt.mjs
-// so warning conditions and messages stay in sync across the checker and the prompt renderer.
+// Advisory process-heavy heuristics: they never fail a board and never rewrite completed
+// history; only future work should be consolidated. Tune via PROCESS_HEAVY_THRESHOLDS:
+// largeUnfinished (unfinished cards, including blocked boards with no active task),
+// ratioMinTasks + processToWorkerRatio (PM/Judge/Scout cards vs Worker cards), and processRun
+// (consecutive dispatched process-only cards since the last Worker card). Keep this function
+// byte-identical to processHeavyWarnings in scripts/render-task-prompt.mjs.
 function processHeavyWarnings(tasks, activeTaskId, goalStatus) {
   const PROCESS_HEAVY_THRESHOLDS = {
     largeUnfinished: 12,

--- a/goalbuddy/scripts/render-task-prompt.mjs
+++ b/goalbuddy/scripts/render-task-prompt.mjs
@@ -167,16 +167,12 @@ function promptWarnings(board, task) {
   return warnings;
 }
 
-// Process-heavy board heuristics. Advisory only: they never fail a board and never ask to
-// rewrite completed history; only future work should be consolidated. Tuning knobs:
-// - largeUnfinished: unfinished (non-done) cards at/above this count warn, including on
-//   blocked boards with no active task.
-// - ratioMinTasks / processToWorkerRatio: once the board has ratioMinTasks cards, warn when
-//   process cards (pm + judge + scout) exceed processToWorkerRatio x Worker cards.
-// - processRun: warn after this many consecutive dispatched (non-queued) process cards
-//   since the last Worker card, because repeated planning/audit adds no new capability.
-// Keep this function byte-identical to processHeavyWarnings in scripts/check-goal-state.mjs
-// so warning conditions and messages stay in sync across the checker and the prompt renderer.
+// Advisory process-heavy heuristics: they never fail a board and never rewrite completed
+// history; only future work should be consolidated. Tune via PROCESS_HEAVY_THRESHOLDS:
+// largeUnfinished (unfinished cards, including blocked boards with no active task),
+// ratioMinTasks + processToWorkerRatio (PM/Judge/Scout cards vs Worker cards), and processRun
+// (consecutive dispatched process-only cards since the last Worker card). Keep this function
+// byte-identical to processHeavyWarnings in scripts/check-goal-state.mjs.
 function processHeavyWarnings(tasks, activeTaskId, goalStatus) {
   const PROCESS_HEAVY_THRESHOLDS = {
     largeUnfinished: 12,

--- a/goalbuddy/scripts/render-task-prompt.mjs
+++ b/goalbuddy/scripts/render-task-prompt.mjs
@@ -163,7 +163,51 @@ function promptWarnings(board, task) {
     }
   }
   warnings.push(...microSliceWarnings(board, task));
+  warnings.push(...processHeavyWarnings(board.tasks.filter(Boolean), board.activeTask || null, board.goal.status));
   return warnings;
+}
+
+// Process-heavy board heuristics. Advisory only: they never fail a board and never ask to
+// rewrite completed history; only future work should be consolidated. Tuning knobs:
+// - largeUnfinished: unfinished (non-done) cards at/above this count warn, including on
+//   blocked boards with no active task.
+// - ratioMinTasks / processToWorkerRatio: once the board has ratioMinTasks cards, warn when
+//   process cards (pm + judge + scout) exceed processToWorkerRatio x Worker cards.
+// - processRun: warn after this many consecutive dispatched (non-queued) process cards
+//   since the last Worker card, because repeated planning/audit adds no new capability.
+// Keep this function byte-identical to processHeavyWarnings in scripts/check-goal-state.mjs
+// so warning conditions and messages stay in sync across the checker and the prompt renderer.
+function processHeavyWarnings(tasks, activeTaskId, goalStatus) {
+  const PROCESS_HEAVY_THRESHOLDS = {
+    largeUnfinished: 12,
+    ratioMinTasks: 12,
+    processToWorkerRatio: 2,
+    processRun: 4,
+  };
+  const { largeUnfinished, ratioMinTasks, processToWorkerRatio, processRun } = PROCESS_HEAVY_THRESHOLDS;
+  const found = [];
+  const consolidate = "Preserve completed history and consolidate only future work into roughly 3-7 outcome-sized phases. Duration alone is not a reason to use GoalBuddy; native Goal may fit a long single-owner sequential run better.";
+  const isWorker = (task) => task.type?.toLowerCase() === "worker";
+  const unfinished = tasks.filter((task) => task.status !== "done");
+  if (unfinished.length >= largeUnfinished) {
+    const stalled = goalStatus !== "active" && !activeTaskId ? " on a blocked board with no active task" : "";
+    found.push(`Board is process-heavy: ${unfinished.length} unfinished tasks${stalled}. ${consolidate}`);
+  }
+  const workerCount = tasks.filter(isWorker).length;
+  const processCount = tasks.length - workerCount;
+  if (tasks.length >= ratioMinTasks && processCount > processToWorkerRatio * Math.max(workerCount, 1)) {
+    found.push(`Board is process-heavy: ${processCount} PM/Judge/Scout tasks vs ${workerCount} Worker tasks. One task should normally include implementation, targeted tests, CI/readback, and proof when authority and risk stay the same. Reserve Scout for material uncertainty and Judge for phase, risk, rejected-verification, or final boundaries.`);
+  }
+  const dispatched = tasks.filter((task) => task.status !== "queued");
+  let run = 0;
+  for (let index = dispatched.length - 1; index >= 0; index -= 1) {
+    if (isWorker(dispatched[index])) break;
+    run += 1;
+  }
+  if (run >= processRun) {
+    found.push(`Board is process-heavy: ${run} consecutive planning, audit, or process-only tasks since the last Worker task added no new verifiable capability. ${consolidate}`);
+  }
+  return found;
 }
 
 function microSliceWarnings(board, task) {

--- a/internal/test/check-goal-state.test.mjs
+++ b/internal/test/check-goal-state.test.mjs
@@ -5,6 +5,8 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { renderTaskPrompt, formatPrompt } from "../../goalbuddy/scripts/render-task-prompt.mjs";
+
 const checker = resolve("goalbuddy/scripts/check-goal-state.mjs");
 
 function makeRoot() {
@@ -329,6 +331,120 @@ checks:
     assert.equal(result.stdout.ok, true);
     assert.match(result.stdout.warnings.join("\n"), /Board may be micro-slicing\. Prefer the largest safe useful slice/i);
     assert.match(result.stdout.warnings.join("\n"), /Micro Worker\/Judge loop detected/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function processHeavyBoard() {
+  const pad = (value) => `T${String(value).padStart(3, "0")}`;
+  const cards = [];
+  let id = 0;
+  cards.push(`  - id: ${pad(++id)}
+    type: worker
+    assignee: Worker
+    status: done
+    objective: "Ship the first outcome slice."
+    allowed_files:
+      - package.json
+    verify:
+      - npm test
+    stop_if:
+      - "Verification fails twice."
+    receipt:
+      result: done
+      changed_files:
+        - package.json
+      commands:
+        - cmd: npm test
+          status: pass
+      summary: "Slice shipped."`);
+  for (let index = 0; index < 8; index += 1) {
+    cards.push(`  - id: ${pad(++id)}
+    type: judge
+    assignee: Judge
+    status: done
+    objective: "Audit micro-step ${id}."
+    receipt:
+      result: done
+      decision: approved`);
+    cards.push(`  - id: ${pad(++id)}
+    type: pm
+    assignee: PM
+    status: done
+    objective: "Plan micro-step ${id}."
+    receipt:
+      result: done
+      summary: "Planned."`);
+  }
+  for (let index = 0; index < 13; index += 1) {
+    cards.push(`  - id: ${pad(++id)}
+    type: pm
+    assignee: PM
+    status: blocked
+    objective: "Process follow-up ${id}."
+    receipt:
+      result: blocked
+      summary: "Waiting on process."`);
+  }
+  return `
+version: 2
+goal:
+  title: "Process heavy"
+  slug: "process-heavy"
+  kind: open_ended
+  tranche: "consolidation"
+  status: blocked
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+active_task: null
+tasks:
+${cards.join("\n")}
+`;
+}
+
+test("warns on process-heavy boards and blocked backlogs without failing them", () => {
+  const root = makeRoot();
+  try {
+    writeState(root, processHeavyBoard());
+    const result = runChecker(root);
+    assert.equal(result.status, 0, result.stderr || JSON.stringify(result.stdout));
+    assert.equal(result.stdout.ok, true);
+    const joined = result.stdout.warnings.join("\n");
+    assert.match(joined, /13 unfinished tasks on a blocked board with no active task/i);
+    assert.match(joined, /29 PM\/Judge\/Scout tasks vs 1 Worker tasks/i);
+    assert.match(joined, /consecutive planning, audit, or process-only tasks/i);
+    assert.match(joined, /consolidate only future work into roughly 3-7 outcome-sized phases/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("prompt renderer surfaces process-heavy warnings without failing the board", () => {
+  const root = makeRoot();
+  try {
+    writeState(root, processHeavyBoard());
+    const result = renderTaskPrompt({ goalRoot: root, taskId: "T030", json: true });
+    const joined = result.payload.metadata.warnings.join("\n");
+    assert.match(joined, /Board is process-heavy/i);
+    assert.match(joined, /PM\/Judge\/Scout tasks vs 1 Worker tasks/i);
+    assert.match(formatPrompt(result.payload), /Board is process-heavy/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("keeps normal small boards free of process-heavy warnings", () => {
+  const root = makeRoot();
+  try {
+    writeState(root, validScoutBoard);
+    const result = runChecker(root);
+    assert.equal(result.stdout.ok, true);
+    assert.doesNotMatch(result.stdout.warnings.join("\n"), /process-heavy/i);
+    const rendered = renderTaskPrompt({ goalRoot: root, taskId: "T001", json: true });
+    assert.doesNotMatch(rendered.payload.metadata.warnings.join("\n"), /process-heavy/i);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/plugins/goalbuddy/skills/goal-prep/SKILL.md
+++ b/plugins/goalbuddy/skills/goal-prep/SKILL.md
@@ -206,6 +206,8 @@ After two tiny tasks in a row, PM or Judge should reorient the board. If a demo 
 
 Tiny tasks are allowed when the failure is isolated, the risk is high, the scope is unknown, or the tiny task unlocks a larger slice. Tiny tasks are bad when they keep happening, do not change behavior, only add wrappers/contracts/proof files, or avoid the real milestone.
 
+One task normally carries its slice end to end: implementation, targeted tests, CI or readback, and proof, whenever authority and risk stay the same. Do not split planning, individual checks, CI, readback, or receipt handling into separate cards; that duplicates native Goal and PR/CI evidence instead of reducing risk. Reserve Scout for material uncertainty and Judge for phase, risk, rejected-verification, or final-completion boundaries.
+
 ## When To Use
 
 Use this skill for goals that are broad, multi-hour, ambiguous, high-risk, already planned, already stale, already red, or likely to need Scout/Judge/Worker delegation.
@@ -300,6 +302,8 @@ The PM owns the board. Scout, Judge, and Worker return receipts; they do not sel
 ## Seed Boards
 
 If the goal is vague, the first active task is Scout, but the seeded board should still lead toward execution. Queue Judge selection, a bounded Worker slot, and a final audit.
+
+Seed roughly 3-7 outcome-sized phases, not a long chain of micro-steps. Duration alone is not a reason to use GoalBuddy; a long single-owner sequential run may fit native Goal better. When an existing board has grown process-heavy, preserve completed history and receipts unchanged and consolidate only the future work into outcome-sized phases.
 
 If the user provides an existing plan, do not ignore it and do not execute it blindly. Preserve the plan in `goal.intake.existing_plan_facts`, make the first active task PM or Judge validation, and queue Worker slices only after the plan is checked for evidence, risk, allowed files, verification, and stop conditions.
 

--- a/plugins/goalbuddy/skills/goal-prep/references/goal-execution.md
+++ b/plugins/goalbuddy/skills/goal-prep/references/goal-execution.md
@@ -225,6 +225,8 @@ If a local board server is running, compare `state.yaml` with `http://127.0.0.1:
 
 Board-health work should verify these truths: `active_task` matches live task status, done and blocked tasks have receipts, human-blocked work is in the blocked column, future work stays queued, and the live board/API reflects `state.yaml`.
 
+The checker and the task-prompt renderer also emit advisory process-heavy warnings. They never fail an otherwise valid board, and they never ask to rewrite completed history or receipts; only future work should be consolidated into roughly 3-7 outcome-sized phases. The thresholds live in `PROCESS_HEAVY_THRESHOLDS` in `scripts/check-goal-state.mjs` (mirrored in `scripts/render-task-prompt.mjs`) and warn when: unfinished cards reach 12 or more, including on blocked boards with no active task; PM/Judge/Scout cards exceed twice the Worker cards once the board has 12 or more cards; or 4 or more consecutive dispatched process-only cards follow the last Worker card without a new verifiable capability.
+
 ## Operator Escalation
 
 When Scout, Judge, Worker, or PM discovers a problem, improvement opportunity, product suggestion, follow-up repair, or tool limitation that should not be fixed inside the current active task, do not let it disappear in chat.

--- a/plugins/goalbuddy/skills/goal-prep/scripts/check-goal-state.mjs
+++ b/plugins/goalbuddy/skills/goal-prep/scripts/check-goal-state.mjs
@@ -452,6 +452,7 @@ for (const task of tasks) {
 }
 
 warnings.push(...microSliceWarnings(tasks, activeTask, goalStatus));
+warnings.push(...processHeavyWarnings(tasks, activeTask, goalStatus));
 
 function isTerminalApprovalWait(tasks, activeTasks, activeTask) {
   if (goalStatus !== "blocked") return false;
@@ -588,6 +589,49 @@ function isTinyTask(task) {
   const text = [task.objective, task.raw, task.receipt?.raw].join(" ").toLowerCase();
   if (/collapsed|batch|package|tranche|vertical slice|milestone/.test(text)) return false;
   return /\b(tiny|narrow|single helper|one helper|projection helper|projection function|contract file|read-only proof|doc note|validator|validation wrapper|pure helper|caller-input)\b/.test(text);
+}
+
+// Process-heavy board heuristics. Advisory only: they never fail a board and never ask to
+// rewrite completed history; only future work should be consolidated. Tuning knobs:
+// - largeUnfinished: unfinished (non-done) cards at/above this count warn, including on
+//   blocked boards with no active task.
+// - ratioMinTasks / processToWorkerRatio: once the board has ratioMinTasks cards, warn when
+//   process cards (pm + judge + scout) exceed processToWorkerRatio x Worker cards.
+// - processRun: warn after this many consecutive dispatched (non-queued) process cards
+//   since the last Worker card, because repeated planning/audit adds no new capability.
+// Keep this function byte-identical to processHeavyWarnings in scripts/render-task-prompt.mjs
+// so warning conditions and messages stay in sync across the checker and the prompt renderer.
+function processHeavyWarnings(tasks, activeTaskId, goalStatus) {
+  const PROCESS_HEAVY_THRESHOLDS = {
+    largeUnfinished: 12,
+    ratioMinTasks: 12,
+    processToWorkerRatio: 2,
+    processRun: 4,
+  };
+  const { largeUnfinished, ratioMinTasks, processToWorkerRatio, processRun } = PROCESS_HEAVY_THRESHOLDS;
+  const found = [];
+  const consolidate = "Preserve completed history and consolidate only future work into roughly 3-7 outcome-sized phases. Duration alone is not a reason to use GoalBuddy; native Goal may fit a long single-owner sequential run better.";
+  const isWorker = (task) => task.type?.toLowerCase() === "worker";
+  const unfinished = tasks.filter((task) => task.status !== "done");
+  if (unfinished.length >= largeUnfinished) {
+    const stalled = goalStatus !== "active" && !activeTaskId ? " on a blocked board with no active task" : "";
+    found.push(`Board is process-heavy: ${unfinished.length} unfinished tasks${stalled}. ${consolidate}`);
+  }
+  const workerCount = tasks.filter(isWorker).length;
+  const processCount = tasks.length - workerCount;
+  if (tasks.length >= ratioMinTasks && processCount > processToWorkerRatio * Math.max(workerCount, 1)) {
+    found.push(`Board is process-heavy: ${processCount} PM/Judge/Scout tasks vs ${workerCount} Worker tasks. One task should normally include implementation, targeted tests, CI/readback, and proof when authority and risk stay the same. Reserve Scout for material uncertainty and Judge for phase, risk, rejected-verification, or final boundaries.`);
+  }
+  const dispatched = tasks.filter((task) => task.status !== "queued");
+  let run = 0;
+  for (let index = dispatched.length - 1; index >= 0; index -= 1) {
+    if (isWorker(dispatched[index])) break;
+    run += 1;
+  }
+  if (run >= processRun) {
+    found.push(`Board is process-heavy: ${run} consecutive planning, audit, or process-only tasks since the last Worker task added no new verifiable capability. ${consolidate}`);
+  }
+  return found;
 }
 
 function matchesAllowedFile(file, allowedFiles) {

--- a/plugins/goalbuddy/skills/goal-prep/scripts/check-goal-state.mjs
+++ b/plugins/goalbuddy/skills/goal-prep/scripts/check-goal-state.mjs
@@ -591,16 +591,12 @@ function isTinyTask(task) {
   return /\b(tiny|narrow|single helper|one helper|projection helper|projection function|contract file|read-only proof|doc note|validator|validation wrapper|pure helper|caller-input)\b/.test(text);
 }
 
-// Process-heavy board heuristics. Advisory only: they never fail a board and never ask to
-// rewrite completed history; only future work should be consolidated. Tuning knobs:
-// - largeUnfinished: unfinished (non-done) cards at/above this count warn, including on
-//   blocked boards with no active task.
-// - ratioMinTasks / processToWorkerRatio: once the board has ratioMinTasks cards, warn when
-//   process cards (pm + judge + scout) exceed processToWorkerRatio x Worker cards.
-// - processRun: warn after this many consecutive dispatched (non-queued) process cards
-//   since the last Worker card, because repeated planning/audit adds no new capability.
-// Keep this function byte-identical to processHeavyWarnings in scripts/render-task-prompt.mjs
-// so warning conditions and messages stay in sync across the checker and the prompt renderer.
+// Advisory process-heavy heuristics: they never fail a board and never rewrite completed
+// history; only future work should be consolidated. Tune via PROCESS_HEAVY_THRESHOLDS:
+// largeUnfinished (unfinished cards, including blocked boards with no active task),
+// ratioMinTasks + processToWorkerRatio (PM/Judge/Scout cards vs Worker cards), and processRun
+// (consecutive dispatched process-only cards since the last Worker card). Keep this function
+// byte-identical to processHeavyWarnings in scripts/render-task-prompt.mjs.
 function processHeavyWarnings(tasks, activeTaskId, goalStatus) {
   const PROCESS_HEAVY_THRESHOLDS = {
     largeUnfinished: 12,

--- a/plugins/goalbuddy/skills/goal-prep/scripts/render-task-prompt.mjs
+++ b/plugins/goalbuddy/skills/goal-prep/scripts/render-task-prompt.mjs
@@ -167,16 +167,12 @@ function promptWarnings(board, task) {
   return warnings;
 }
 
-// Process-heavy board heuristics. Advisory only: they never fail a board and never ask to
-// rewrite completed history; only future work should be consolidated. Tuning knobs:
-// - largeUnfinished: unfinished (non-done) cards at/above this count warn, including on
-//   blocked boards with no active task.
-// - ratioMinTasks / processToWorkerRatio: once the board has ratioMinTasks cards, warn when
-//   process cards (pm + judge + scout) exceed processToWorkerRatio x Worker cards.
-// - processRun: warn after this many consecutive dispatched (non-queued) process cards
-//   since the last Worker card, because repeated planning/audit adds no new capability.
-// Keep this function byte-identical to processHeavyWarnings in scripts/check-goal-state.mjs
-// so warning conditions and messages stay in sync across the checker and the prompt renderer.
+// Advisory process-heavy heuristics: they never fail a board and never rewrite completed
+// history; only future work should be consolidated. Tune via PROCESS_HEAVY_THRESHOLDS:
+// largeUnfinished (unfinished cards, including blocked boards with no active task),
+// ratioMinTasks + processToWorkerRatio (PM/Judge/Scout cards vs Worker cards), and processRun
+// (consecutive dispatched process-only cards since the last Worker card). Keep this function
+// byte-identical to processHeavyWarnings in scripts/check-goal-state.mjs.
 function processHeavyWarnings(tasks, activeTaskId, goalStatus) {
   const PROCESS_HEAVY_THRESHOLDS = {
     largeUnfinished: 12,

--- a/plugins/goalbuddy/skills/goal-prep/scripts/render-task-prompt.mjs
+++ b/plugins/goalbuddy/skills/goal-prep/scripts/render-task-prompt.mjs
@@ -163,7 +163,51 @@ function promptWarnings(board, task) {
     }
   }
   warnings.push(...microSliceWarnings(board, task));
+  warnings.push(...processHeavyWarnings(board.tasks.filter(Boolean), board.activeTask || null, board.goal.status));
   return warnings;
+}
+
+// Process-heavy board heuristics. Advisory only: they never fail a board and never ask to
+// rewrite completed history; only future work should be consolidated. Tuning knobs:
+// - largeUnfinished: unfinished (non-done) cards at/above this count warn, including on
+//   blocked boards with no active task.
+// - ratioMinTasks / processToWorkerRatio: once the board has ratioMinTasks cards, warn when
+//   process cards (pm + judge + scout) exceed processToWorkerRatio x Worker cards.
+// - processRun: warn after this many consecutive dispatched (non-queued) process cards
+//   since the last Worker card, because repeated planning/audit adds no new capability.
+// Keep this function byte-identical to processHeavyWarnings in scripts/check-goal-state.mjs
+// so warning conditions and messages stay in sync across the checker and the prompt renderer.
+function processHeavyWarnings(tasks, activeTaskId, goalStatus) {
+  const PROCESS_HEAVY_THRESHOLDS = {
+    largeUnfinished: 12,
+    ratioMinTasks: 12,
+    processToWorkerRatio: 2,
+    processRun: 4,
+  };
+  const { largeUnfinished, ratioMinTasks, processToWorkerRatio, processRun } = PROCESS_HEAVY_THRESHOLDS;
+  const found = [];
+  const consolidate = "Preserve completed history and consolidate only future work into roughly 3-7 outcome-sized phases. Duration alone is not a reason to use GoalBuddy; native Goal may fit a long single-owner sequential run better.";
+  const isWorker = (task) => task.type?.toLowerCase() === "worker";
+  const unfinished = tasks.filter((task) => task.status !== "done");
+  if (unfinished.length >= largeUnfinished) {
+    const stalled = goalStatus !== "active" && !activeTaskId ? " on a blocked board with no active task" : "";
+    found.push(`Board is process-heavy: ${unfinished.length} unfinished tasks${stalled}. ${consolidate}`);
+  }
+  const workerCount = tasks.filter(isWorker).length;
+  const processCount = tasks.length - workerCount;
+  if (tasks.length >= ratioMinTasks && processCount > processToWorkerRatio * Math.max(workerCount, 1)) {
+    found.push(`Board is process-heavy: ${processCount} PM/Judge/Scout tasks vs ${workerCount} Worker tasks. One task should normally include implementation, targeted tests, CI/readback, and proof when authority and risk stay the same. Reserve Scout for material uncertainty and Judge for phase, risk, rejected-verification, or final boundaries.`);
+  }
+  const dispatched = tasks.filter((task) => task.status !== "queued");
+  let run = 0;
+  for (let index = dispatched.length - 1; index >= 0; index -= 1) {
+    if (isWorker(dispatched[index])) break;
+    run += 1;
+  }
+  if (run >= processRun) {
+    found.push(`Board is process-heavy: ${run} consecutive planning, audit, or process-only tasks since the last Worker task added no new verifiable capability. ${consolidate}`);
+  }
+  return found;
 }
 
 function microSliceWarnings(board, task) {


### PR DESCRIPTION
Fixes #44.

## Summary

Warn when boards become process-heavy and micro-sliced

## Validation

- Mechanical gate: +288/-0, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->