### PR TITLE
docs: keep release history client-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This is GoalBuddy's single, running release history. New releases go at the top.
 
 Dates are public npm publication dates. Historical entries describe the product as it behaved in that release, with explicit notes where a later release superseded the behavior.
 
+Release history must describe product behavior with anonymized evidence. Never include client, customer, company, donor, or private project names. Public contributor handles may appear only for attribution.
+
 ## 0.4.3: Restore Claude's Native `/goal` (2026-08-05)
 
 - **Claude Code keeps its native `/goal`.** GoalBuddy now installs its execution loop as `/goalbuddy`, removing the namespace collision introduced in 0.4.0.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -4,6 +4,8 @@ The repository has one canonical, running release history: [CHANGELOG.md](../../
 
 This directory contains the release process only. Published GitHub Releases remain immutable public snapshots and should use the matching section of `CHANGELOG.md` as their source copy.
 
+Keep every changelog section and GitHub Release body client-safe. Describe the observed behavior generically and never include client, customer, company, donor, or private project names. Public contributor attribution is allowed.
+
 GoalBuddy publishes the `goalbuddy` npm package from GitHub Actions using npm trusted publishing. This avoids long-lived npm write tokens and lets npm generate provenance for future releases.
 
 ## One-Time npm Setup

--- a/internal/test/package-files.test.mjs
+++ b/internal/test/package-files.test.mjs
@@ -14,6 +14,8 @@ test("release history stays in one running changelog", () => {
   const changelog = readFileSync("CHANGELOG.md", "utf8");
   assert.match(changelog, /single, running release history/);
   assert.match(changelog, /Do not create separate versioned changelog files/);
+  assert.match(changelog, /Never include client, customer, company, donor, or private project names/);
+  assert.doesNotMatch(changelog, /FL Donate/i);
 
   for (const version of [
     "0.4.3", "0.4.2", "0.4.1", "0.4.0",


### PR DESCRIPTION
## What changed

- added a permanent rule that changelogs and GitHub Release bodies must use anonymized evidence
- explicitly prohibited client, customer, company, donor, and private project names
- allowed public contributor handles only for attribution
- added regression coverage for the policy and the known client-name leak

## Published history cleanup

The live v0.4.2 GitHub Release contained two references to a private client name. Both were replaced with generic descriptions of the real-world GoalBuddy run. A live sweep confirmed no GoalBuddy Release body now matches that client name or generic client/customer language.

## Verification

- Node 24.19: `npm run check` (133 tests passed)
- targeted packed-package and changelog tests passed
- `git diff --check`
- live GitHub Release sweep returned no matches

No package version or npm release is needed for this documentation-policy fix.
