### PR TITLE
fix: let users uninstall the Codex plugin from the catalog

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -11,7 +11,7 @@
         "path": "./plugins/goalbuddy"
       },
       "policy": {
-        "installation": "INSTALLED_BY_DEFAULT",
+        "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
       "category": "Coding"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Dates are public npm publication dates. Historical entries describe the product 
 
 Release history must describe product behavior with anonymized evidence. Never include client, customer, company, donor, or private project names. Public contributor handles may appear only for attribution.
 
+## Unreleased
+
+- **The Codex plugin can be uninstalled from the plugin catalog again.** The marketplace entry declared `INSTALLED_BY_DEFAULT`, which Codex reads as admin-managed: the catalog labelled GoalBuddy "Installed by admin" and replaced its uninstall action with a disabled row. GoalBuddy is user-installed, so the entry now declares `AVAILABLE`.
+
 ## 0.4.3: Restore Claude's Native `/goal` (2026-08-05)
 
 - **Claude Code keeps its native `/goal`.** GoalBuddy now installs its execution loop as `/goalbuddy`, removing the namespace collision introduced in 0.4.0.

--- a/internal/test/plugin-marketplace.test.mjs
+++ b/internal/test/plugin-marketplace.test.mjs
@@ -17,7 +17,9 @@ test("GoalBuddy plugin is exposed through a Codex marketplace manifest", () => {
   assert.equal(entry.name, "goalbuddy");
   assert.equal(entry.source.source, "local");
   assert.equal(entry.source.path, "./plugins/goalbuddy");
-  assert.equal(entry.policy.installation, "INSTALLED_BY_DEFAULT");
+  // Codex reads INSTALLED_BY_DEFAULT as admin-managed: it labels the plugin "Installed by admin"
+  // and replaces the uninstall action with a disabled row. GoalBuddy is user-installed.
+  assert.equal(entry.policy.installation, "AVAILABLE");
   assert.equal(entry.category, "Coding");
 });
 


### PR DESCRIPTION
## Summary

The Codex marketplace entry declares `"installation": "INSTALLED_BY_DEFAULT"`. Codex reads that as an admin-managed deployment, so the plugin catalog labels GoalBuddy "Installed by admin" and renders a **disabled row in place of the uninstall action**. A user who installed GoalBuddy themselves cannot remove it from the catalog.

This changes the entry to `"AVAILABLE"`, which is also the enum's default.

## Evidence

`codex-rs/tui/src/chatwidget/plugin_catalog.rs` builds the action row:

```rust
if plugin.summary.install_policy == PluginInstallPolicy::InstalledByDefault {
    // ... name: "Installed by admin"
    // ... is_disabled: true
} else if let Some(plugin_id) = plugin_uninstall_id(&plugin.summary) {
    // the uninstall action
}
```

The same policy also drives the "Admin assigned" and "Enabled by Admin" labels elsewhere in the catalog. It does not trigger auto-install anywhere in core, so the current value buys nothing and costs the uninstall action.

`MarketplacePluginInstallPolicy` in `codex-rs/core-plugins/src/marketplace.rs` marks `Available` as `#[default]`.

`"authentication": "ON_INSTALL"` is left as is: that is also its enum default.

## Test plan

- [x] `npm run check` passes (109 internal tests).
- [x] The existing marketplace-manifest test asserted the old value, so it is updated with a comment recording why `AVAILABLE` is correct.
