### PR TITLE
fix: prune stale Codex plugin version directories on install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Dates are public npm publication dates. Historical entries describe the product 
 
 Release history must describe product behavior with anonymized evidence. Never include client, customer, company, donor, or private project names. Public contributor handles may appear only for attribution.
 
+## Unreleased
+
+- **A downgrade no longer keeps the newer Codex plugin live.** Install removed only the version directory it was about to write, but Codex serves the highest version directory it finds under the plugin cache, so a directory left behind by a newer install kept being served. Install now prunes stale sibling version directories the way Codex's own installer does, and leaves directories that are not valid version segments alone.
+
 ## 0.4.3: Restore Claude's Native `/goal` (2026-08-05)
 
 - **Claude Code keeps its native `/goal`.** GoalBuddy now installs its execution loop as `/goalbuddy`, removing the namespace collision introduced in 0.4.0.

--- a/internal/cli/goal-maker.mjs
+++ b/internal/cli/goal-maker.mjs
@@ -977,6 +977,8 @@ function installPlugin({ quiet = false } = {}) {
   mkdirSync(dirname(pluginCachePath), { recursive: true });
   rmSync(pluginCachePath, { recursive: true, force: true });
   cpSync(pluginSource, pluginCachePath, { recursive: true });
+  // Prune only after the new version is in place, so a failed copy cannot leave the cache empty.
+  const removedStaleVersionPaths = pruneStalePluginVersions(pluginManifest.version);
   const removedLegacySkillPaths = cleanupLegacyCodexSkills();
   const configPath = enablePluginConfig();
   const agents = installAgents({ quiet: true });
@@ -992,6 +994,7 @@ function installPlugin({ quiet = false } = {}) {
     config_path: configPath,
     agents,
     removed_legacy_skill_paths: removedLegacySkillPaths,
+    removed_stale_version_paths: removedStaleVersionPaths,
   };
 
   if (hasFlag("--json") && !quiet) {
@@ -1008,6 +1011,9 @@ function installPlugin({ quiet = false } = {}) {
   console.log(`Agents: ${summarizeStatuses(report.agents)}`);
   if (report.removed_legacy_skill_paths.length) {
     console.log(`Removed legacy personal skills: ${report.removed_legacy_skill_paths.join(", ")}`);
+  }
+  if (report.removed_stale_version_paths.length) {
+    console.log(`Removed stale plugin versions: ${report.removed_stale_version_paths.join(", ")}`);
   }
   console.log("");
   console.log("Restart Codex, then use:");
@@ -1113,6 +1119,32 @@ function removeTomlTable(text, header) {
 
   if (!removed) return text;
   return output.join("\n").replace(/\n{3,}/g, "\n\n").replace(/\n*$/, "\n");
+}
+
+// Codex serves the highest version directory it finds under the plugin's cache root, so a directory
+// left behind by a newer install keeps being served after a downgrade. Codex's own installer prunes
+// siblings whenever it installs; this mirrors that so a hand-built cache cannot diverge.
+function pruneStalePluginVersions(installedVersion) {
+  const versionsRoot = dirname(pluginCacheRoot(installedVersion));
+  if (!existsSync(versionsRoot)) return [];
+
+  const removed = [];
+  for (const entry of readdirSync(versionsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === installedVersion) continue;
+    if (!isPluginVersionSegment(entry.name)) continue;
+    const path = join(versionsRoot, entry.name);
+    rmSync(path, { recursive: true, force: true });
+    removed.push(path);
+  }
+  return removed;
+}
+
+// Mirrors Codex's validate_plugin_version_segment: non-empty, not a traversal, and limited to ASCII
+// letters, digits, `.`, `+`, `_`, and `-`. Anything else is not a version directory Codex would
+// activate, so it is left alone.
+function isPluginVersionSegment(name) {
+  if (!name || name === "." || name === "..") return false;
+  return /^[A-Za-z0-9._+-]+$/.test(name);
 }
 
 function pluginCacheOwnerRoot() {

--- a/internal/test/goal-maker-cli.test.mjs
+++ b/internal/test/goal-maker-cli.test.mjs
@@ -1063,6 +1063,58 @@ test("plugin install ignores non-version cache directories", () => {
   }
 });
 
+test("plugin install removes a newer stale version directory", () => {
+  const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    const env = fakeCodexEnv(root);
+
+    const install = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    // simulate a downgrade: a directory left behind by a newer install. Codex activates the highest
+    // version it finds, so this would keep being served instead of the version just installed.
+    const versionsRoot = join(codexHome, "plugins", "cache", "goalbuddy", "goalbuddy");
+    const staleVersion = join(versionsRoot, "9.9.9");
+    mkdirSync(staleVersion, { recursive: true });
+    writeFileSync(join(staleVersion, "marker.txt"), "stale\n");
+
+    const reinstall = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(reinstall.status, 0, reinstall.stderr || reinstall.stdout);
+
+    const report = JSON.parse(reinstall.stdout);
+    assert.ok(report.removed_stale_version_paths.includes(staleVersion), JSON.stringify(report.removed_stale_version_paths));
+    assert.equal(existsSync(staleVersion), false);
+    assert.deepEqual(readdirSync(versionsRoot).sort(), [packageVersion]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("plugin install leaves directories that are not plugin versions alone", () => {
+  const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    const env = fakeCodexEnv(root);
+
+    const install = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    // Codex only activates directories whose name is a valid version segment, so anything else is
+    // not ours to delete.
+    const versionsRoot = join(codexHome, "plugins", "cache", "goalbuddy", "goalbuddy");
+    const unrelated = join(versionsRoot, "notes for me");
+    mkdirSync(unrelated, { recursive: true });
+
+    const reinstall = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(reinstall.status, 0, reinstall.stderr || reinstall.stdout);
+    assert.equal(existsSync(unrelated), true);
+    assert.deepEqual(JSON.parse(reinstall.stdout).removed_stale_version_paths, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("plugin reinstall does not leave empty preserved cache directories", () => {
   const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
   try {


### PR DESCRIPTION
## Summary

`plugin install` removed only the version directory it was about to write, leaving any sibling from an earlier install in place. Codex resolves the active plugin by scanning that directory and taking the highest version it finds, so a directory left behind by a newer install keeps being served after a downgrade.

Install 0.5.0, downgrade to 0.4.3, and Codex still loads 0.5.0.

Install now prunes stale sibling version directories, which is what Codex's own installer does after it stages a new version.

## Evidence

`codex-rs/core-plugins/src/store.rs`, `active_plugin_version` sorts ascending and takes the last entry:

```rust
discovered_versions.sort_unstable_by(|left, right| compare_plugin_versions(left, right));
...
discovered_versions.pop()
```

Codex's own installer calls `remove_old_plugin_versions` after staging, which skips the version being installed and any name that is not a valid version segment.

## Notes

- Pruning runs **after** the new version is copied into place, so a failed copy cannot leave the cache empty.
- The version-segment rule mirrors Codex's `validate_plugin_version_segment` (non-empty, not a traversal, ASCII letters, digits, `.`, `+`, `_`, `-`). Directories that fail it are left alone, since Codex would never activate them.
- The report gains `removed_stale_version_paths` so the action is visible rather than silent.

## Test plan

- [x] `npm run check` passes (111 internal tests).
- [x] New coverage: a newer stale version directory is removed and reported; a directory whose name is not a valid version segment is left in place. The two pre-existing plugin-cache tests still pass.
