### PR TITLE
feat: install the Codex plugin through the codex CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Dates are public npm publication dates. Historical entries describe the product 
 
 Release history must describe product behavior with anonymized evidence. Never include client, customer, company, donor, or private project names. Public contributor handles may appear only for attribution.
 
+## Unreleased
+
+- **A downgrade no longer keeps the newer Codex plugin live.** Install removed only the version directory it was about to write, but Codex serves the highest version directory it finds under the plugin cache, so a directory left behind by a newer install kept being served. Install now prunes stale sibling version directories the way Codex's own installer does, and leaves directories that are not valid version segments alone.
+
 ## 0.4.3: Restore Claude's Native `/goal` (2026-08-05)
 
 - **Claude Code keeps its native `/goal`.** GoalBuddy now installs its execution loop as `/goalbuddy`, removing the namespace collision introduced in 0.4.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release history must describe product behavior with anonymized evidence. Never i
 
 ## Unreleased
 
+- **Codex installs through its own CLI.** `codex plugin add` now performs the install against the published marketplace, the same source the docs name, so the entry written into your `config.toml` stays portable. Codex stages the tree and renames it into place, prunes superseded versions, migrates the plugin's `commands/` into skills, and writes the config enablement, instead of GoalBuddy re-implementing those steps. When the `codex` CLI is missing or cannot install, the installer falls back to copying the bundled tree and says which model it used.
 - **A downgrade no longer keeps the newer Codex plugin live.** Install removed only the version directory it was about to write, but Codex serves the highest version directory it finds under the plugin cache, so a directory left behind by a newer install kept being served. Install now prunes stale sibling version directories the way Codex's own installer does, and leaves directories that are not valid version segments alone.
 
 ## 0.4.3: Restore Claude's Native `/goal` (2026-08-05)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ For Codex, the canonical install is the native plugin plus bundled agents:
 ~/.codex/agents/goal_worker.toml
 ```
 
+The install runs through the `codex` CLI:
+
+```bash
+codex plugin marketplace add tolibear/goalbuddy
+codex plugin add goalbuddy@goalbuddy
+```
+
+Codex stages the plugin, prunes superseded versions, migrates the plugin's commands into skills, and enables it in `config.toml` itself. Without a working `codex` CLI the installer copies the bundled tree into the plugin cache instead and reports that it did, so an offline install still produces a loadable plugin.
+
 The Codex plugin bundles `$goal-prep`; a clean Codex install should not need personal `~/.codex/skills/goalbuddy` or `~/.codex/skills/goal-maker` folders. Native Codex `/goal` is a separate OpenAI-gated feature. GoalBuddy prepares local boards and handoff prompts for it, but it does not enable or replace native `/goal`.
 
 To verify a Codex install:

--- a/internal/cli/goal-maker.mjs
+++ b/internal/cli/goal-maker.mjs
@@ -977,6 +977,8 @@ function installPlugin({ quiet = false } = {}) {
   mkdirSync(dirname(pluginCachePath), { recursive: true });
   rmSync(pluginCachePath, { recursive: true, force: true });
   cpSync(pluginSource, pluginCachePath, { recursive: true });
+  // Prune only after the new version is in place, so a failed copy cannot leave the cache empty.
+  const removedStaleVersionPaths = pruneStalePluginVersions(pluginManifest.version);
   const removedLegacySkillPaths = cleanupLegacyCodexSkills();
   const configPath = enablePluginConfig();
   const agents = installAgents({ quiet: true });
@@ -992,6 +994,7 @@ function installPlugin({ quiet = false } = {}) {
     config_path: configPath,
     agents,
     removed_legacy_skill_paths: removedLegacySkillPaths,
+    removed_stale_version_paths: removedStaleVersionPaths,
   };
 
   if (hasFlag("--json") && !quiet) {
@@ -1008,6 +1011,9 @@ function installPlugin({ quiet = false } = {}) {
   console.log(`Agents: ${summarizeStatuses(report.agents)}`);
   if (report.removed_legacy_skill_paths.length) {
     console.log(`Removed legacy personal skills: ${report.removed_legacy_skill_paths.join(", ")}`);
+  }
+  if (report.removed_stale_version_paths.length) {
+    console.log(`Removed stale plugin versions: ${report.removed_stale_version_paths.join(", ")}`);
   }
   console.log("");
   console.log("Restart Codex, then use:");
@@ -1113,6 +1119,32 @@ function removeTomlTable(text, header) {
 
   if (!removed) return text;
   return output.join("\n").replace(/\n{3,}/g, "\n\n").replace(/\n*$/, "\n");
+}
+
+// Codex serves the highest version directory it finds under the plugin's cache root, so a directory
+// left behind by a newer install keeps being served after a downgrade. Codex's own installer prunes
+// siblings whenever it installs; this mirrors that so a hand-built cache cannot diverge.
+function pruneStalePluginVersions(installedVersion) {
+  const versionsRoot = dirname(pluginCacheRoot(installedVersion));
+  if (!existsSync(versionsRoot)) return [];
+
+  const removed = [];
+  for (const entry of readdirSync(versionsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === installedVersion) continue;
+    if (!isPluginVersionSegment(entry.name)) continue;
+    const path = join(versionsRoot, entry.name);
+    rmSync(path, { recursive: true, force: true });
+    removed.push(path);
+  }
+  return removed;
+}
+
+// Mirrors Codex's validate_plugin_version_segment: non-empty, not a traversal, and limited to ASCII
+// letters, digits, `.`, `+`, `_`, and `-`. Anything else is not a version directory Codex would
+// activate, so it is left alone.
+function isPluginVersionSegment(name) {
+  if (!name || name === "." || name === "..") return false;
+  return /^[A-Za-z0-9._+-]+$/.test(name);
 }
 
 function pluginCacheOwnerRoot() {

--- a/internal/cli/goal-maker.mjs
+++ b/internal/cli/goal-maker.mjs
@@ -969,18 +969,31 @@ function installPlugin({ quiet = false } = {}) {
 
   const pluginManifest = JSON.parse(readFileSync(pluginManifestPath, "utf8"));
   const pluginCachePath = pluginCacheRoot(pluginManifest.version);
-  const marketplace = runCodex(["plugin", "marketplace", "add", source]);
-  if (!marketplace.ok) {
-    throw new Error(`Failed to add Codex plugin marketplace: ${firstLine(marketplace.stderr || marketplace.stdout)}`);
+  const warnings = [];
+
+  // Prefer Codex's own installer. It stages the tree into a temp directory and renames it into
+  // place, prunes superseded version directories, migrates `commands/` into skills, and writes the
+  // config enablement, none of which a plain copy does.
+  const native = installPluginWithCodexCli(source);
+  const removedStaleVersionPaths = [];
+  if (!native.ok) {
+    // Falling back to the bundled tree keeps the install working with no `codex` CLI and no network.
+    // Codex loads a plugin from its cache directory plus the `[plugins]` config, both written below,
+    // and consults the marketplace entry only to find the source again later.
+    warnings.push(`Codex CLI install unavailable (${native.reason}). Installed the bundled copy directly; \`codex plugin add\` would also migrate the plugin's commands into skills.`);
+
+    mkdirSync(dirname(pluginCachePath), { recursive: true });
+    rmSync(pluginCachePath, { recursive: true, force: true });
+    cpSync(pluginSource, pluginCachePath, { recursive: true });
+    // Prune only after the new version is in place, so a failed copy cannot leave the cache empty.
+    removedStaleVersionPaths.push(...pruneStalePluginVersions(pluginManifest.version));
   }
 
-  mkdirSync(dirname(pluginCachePath), { recursive: true });
-  rmSync(pluginCachePath, { recursive: true, force: true });
-  cpSync(pluginSource, pluginCachePath, { recursive: true });
-  // Prune only after the new version is in place, so a failed copy cannot leave the cache empty.
-  const removedStaleVersionPaths = pruneStalePluginVersions(pluginManifest.version);
   const removedLegacySkillPaths = cleanupLegacyCodexSkills();
-  const configPath = enablePluginConfig();
+  // `codex plugin add` already enables the plugin, so only write config when it is not enabled yet.
+  const configPath = join(codexHome(), "config.toml");
+  if (!pluginConfigEnabled(configPath)) enablePluginConfig();
+  // Codex plugins cannot bundle subagents, so the role files always install as loose config files.
   const agents = installAgents({ quiet: true });
 
   const report = {
@@ -989,12 +1002,14 @@ function installPlugin({ quiet = false } = {}) {
     plugin: `${pluginName}@${pluginName}`,
     version: pluginManifest.version,
     codex_home: codexHome(),
+    install_model: native.ok ? "codex-cli" : "bundled-copy",
     marketplace_source: source,
     cache_path: pluginCachePath,
     config_path: configPath,
     agents,
     removed_legacy_skill_paths: removedLegacySkillPaths,
     removed_stale_version_paths: removedStaleVersionPaths,
+    warnings,
   };
 
   if (hasFlag("--json") && !quiet) {
@@ -1005,7 +1020,7 @@ function installPlugin({ quiet = false } = {}) {
   if (quiet) return report;
 
   console.log(`Installed ${canonicalProductName} Codex plugin ${pluginManifest.version}`);
-  console.log(`Marketplace: ${source}`);
+  console.log(`Marketplace: ${report.marketplace_source}`);
   console.log(`Cache: ${pluginCachePath}`);
   console.log(`Config: ${configPath}`);
   console.log(`Agents: ${summarizeStatuses(report.agents)}`);
@@ -1119,6 +1134,26 @@ function removeTomlTable(text, header) {
 
   if (!removed) return text;
   return output.join("\n").replace(/\n{3,}/g, "\n\n").replace(/\n*$/, "\n");
+}
+
+// Installs through the `codex` CLI so Codex owns staging, pruning, command migration, and config
+// enablement. The marketplace is the published repository, the same source the docs and the in-app
+// instructions name, so the entry written into the user's config stays portable. Returns
+// `{ ok: false, reason }` when the CLI cannot do it, so the caller can fall back to copying the
+// bundled tree.
+function installPluginWithCodexCli(source) {
+  if (!runCodex(["--version"]).ok) return { ok: false, reason: "codex CLI not found on PATH" };
+
+  const marketplace = runCodex(["plugin", "marketplace", "add", source]);
+  if (!marketplace.ok) {
+    return { ok: false, reason: firstLine(marketplace.stderr || marketplace.stdout) || "marketplace add failed" };
+  }
+
+  const added = runCodex(["plugin", "add", `${pluginName}@${pluginName}`]);
+  if (!added.ok) {
+    return { ok: false, reason: firstLine(added.stderr || added.stdout) || "plugin add failed" };
+  }
+  return { ok: true, reason: "" };
 }
 
 // Codex serves the highest version directory it finds under the plugin's cache root, so a directory

--- a/internal/test/goal-maker-cli.test.mjs
+++ b/internal/test/goal-maker-cli.test.mjs
@@ -1063,6 +1063,58 @@ test("plugin install ignores non-version cache directories", () => {
   }
 });
 
+test("plugin install removes a newer stale version directory", () => {
+  const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    const env = fakeCodexEnv(root);
+
+    const install = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    // simulate a downgrade: a directory left behind by a newer install. Codex activates the highest
+    // version it finds, so this would keep being served instead of the version just installed.
+    const versionsRoot = join(codexHome, "plugins", "cache", "goalbuddy", "goalbuddy");
+    const staleVersion = join(versionsRoot, "9.9.9");
+    mkdirSync(staleVersion, { recursive: true });
+    writeFileSync(join(staleVersion, "marker.txt"), "stale\n");
+
+    const reinstall = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(reinstall.status, 0, reinstall.stderr || reinstall.stdout);
+
+    const report = JSON.parse(reinstall.stdout);
+    assert.ok(report.removed_stale_version_paths.includes(staleVersion), JSON.stringify(report.removed_stale_version_paths));
+    assert.equal(existsSync(staleVersion), false);
+    assert.deepEqual(readdirSync(versionsRoot).sort(), [packageVersion]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("plugin install leaves directories that are not plugin versions alone", () => {
+  const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    const env = fakeCodexEnv(root);
+
+    const install = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    // Codex only activates directories whose name is a valid version segment, so anything else is
+    // not ours to delete.
+    const versionsRoot = join(codexHome, "plugins", "cache", "goalbuddy", "goalbuddy");
+    const unrelated = join(versionsRoot, "notes for me");
+    mkdirSync(unrelated, { recursive: true });
+
+    const reinstall = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(reinstall.status, 0, reinstall.stderr || reinstall.stdout);
+    assert.equal(existsSync(unrelated), true);
+    assert.deepEqual(JSON.parse(reinstall.stdout).removed_stale_version_paths, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("plugin reinstall does not leave empty preserved cache directories", () => {
   const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
   try {

--- a/internal/test/goal-maker-cli.test.mjs
+++ b/internal/test/goal-maker-cli.test.mjs
@@ -42,7 +42,11 @@ function receiptContractSchema(agentPath) {
   return JSON.parse(match[1]);
 }
 
-function fakeCodexBin(root, { loggedIn = true, goalsEnabled = true } = {}) {
+// `nativeInstall` mirrors a real codex CLI, which can install a plugin itself: `plugin add` copies
+// the tree out of the registered marketplace, prunes superseded versions, and enables the plugin in
+// config.toml. Set it false to make `plugin add` fail so the installer takes its bundled-copy
+// fallback. The win32 stub stays minimal (CI is linux), so nativeInstall is posix-only.
+function fakeCodexBin(root, { loggedIn = true, goalsEnabled = true, nativeInstall = true } = {}) {
   const bin = join(root, "bin");
   mkdirSync(bin, { recursive: true });
   if (process.platform === "win32") {
@@ -71,8 +75,34 @@ function fakeCodexBin(root, { loggedIn = true, goalsEnabled = true } = {}) {
       `  echo "goals                               under development  ${goalsEnabled ? "true" : "false"}"; exit 0`,
       "fi",
       "if [ \"$1\" = \"plugin\" ] && [ \"$2\" = \"marketplace\" ] && [ \"$3\" = \"add\" ]; then",
+      "  mkdir -p \"$CODEX_HOME\"",
+      "  printf '%s\\n' \"$4\" > \"$CODEX_HOME/.fake-marketplace-src\"",
       "  echo \"Added marketplace goalbuddy\"; exit 0",
       "fi",
+      ...(nativeInstall
+        ? [
+          "if [ \"$1\" = \"plugin\" ] && [ \"$2\" = \"add\" ]; then",
+          "  src=$(cat \"$CODEX_HOME/.fake-marketplace-src\" 2>/dev/null)",
+          "  [ -n \"$src\" ] || exit 1",
+          // a real CLI clones the marketplace repo; stand in for that clone with this checkout
+          "  if [ -d \"$src/plugins/goalbuddy\" ]; then tree=\"$src/plugins/goalbuddy\"; else tree=\"$PWD/plugins/goalbuddy\"; fi",
+          "  [ -d \"$tree\" ] || exit 1",
+          "  ver=$(sed -n 's/.*\"version\": *\"\\([^\"]*\\)\".*/\\1/p' \"$tree/.codex-plugin/plugin.json\" | head -1)",
+          "  [ -n \"$ver\" ] || exit 1",
+          "  cacheRoot=\"$CODEX_HOME/plugins/cache/goalbuddy/goalbuddy\"",
+          "  rm -rf \"$cacheRoot/$ver\"; mkdir -p \"$cacheRoot/$ver\"",
+          "  cp -R \"$tree/.\" \"$cacheRoot/$ver/\"",
+          "  for d in \"$cacheRoot\"/*; do",
+          "    [ -d \"$d\" ] || continue",
+          "    [ \"$(basename \"$d\")\" = \"$ver\" ] || rm -rf \"$d\"",
+          "  done",
+          "  grep -q 'goalbuddy@goalbuddy' \"$CODEX_HOME/config.toml\" 2>/dev/null || printf '[plugins.\"goalbuddy@goalbuddy\"]\\nenabled = true\\n' >> \"$CODEX_HOME/config.toml\"",
+          "  echo \"Installed goalbuddy@goalbuddy\"; exit 0",
+          "fi",
+        ]
+        : [
+          "if [ \"$1\" = \"plugin\" ] && [ \"$2\" = \"add\" ]; then echo \"plugin add unsupported\" 1>&2; exit 1; fi",
+        ]),
       "exit 2",
       "",
     ].join("\n");
@@ -1063,11 +1093,56 @@ test("plugin install ignores non-version cache directories", () => {
   }
 });
 
-test("plugin install removes a newer stale version directory", () => {
+test("plugin install uses the codex CLI and installs the bundled version", () => {
   const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
   try {
     const codexHome = join(root, "codex-home");
     const env = fakeCodexEnv(root);
+
+    const install = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    const report = JSON.parse(install.stdout);
+    assert.equal(report.install_model, "codex-cli");
+    assert.deepEqual(report.warnings, []);
+    // the published repository, matching what the docs and the in-app instructions tell users to add
+    assert.equal(report.marketplace_source, "tolibear/goalbuddy");
+    assert.equal(report.version, packageVersion);
+    assert.equal(existsSync(join(report.cache_path, "skills", "goal-prep", "SKILL.md")), true);
+    assert.match(readFileSync(join(codexHome, "config.toml"), "utf8"), /\[plugins\."goalbuddy@goalbuddy"\]/);
+    assert.equal(existsSync(join(codexHome, "agents", "goal_scout.toml")), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("plugin install falls back to the bundled copy when the codex CLI cannot install", () => {
+  const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    const env = fakeCodexEnv(root, { nativeInstall: false });
+
+    const install = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    const report = JSON.parse(install.stdout);
+    assert.equal(report.install_model, "bundled-copy");
+    assert.match(report.warnings.join("\n"), /Codex CLI install unavailable/);
+    // the fallback still produces a loadable install: cache, config, and agents
+    assert.equal(existsSync(join(report.cache_path, "skills", "goal-prep", "SKILL.md")), true);
+    assert.match(readFileSync(join(codexHome, "config.toml"), "utf8"), /enabled = true/);
+    assert.equal(existsSync(join(codexHome, "agents", "goal_scout.toml")), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the bundled-copy install removes a newer stale version directory", () => {
+  const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    // Codex prunes for us on the native path, so this covers the fallback that copies the tree.
+    const env = fakeCodexEnv(root, { nativeInstall: false });
 
     const install = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
     assert.equal(install.status, 0, install.stderr || install.stdout);
@@ -1091,11 +1166,11 @@ test("plugin install removes a newer stale version directory", () => {
   }
 });
 
-test("plugin install leaves directories that are not plugin versions alone", () => {
+test("the bundled-copy install leaves directories that are not plugin versions alone", () => {
   const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
   try {
     const codexHome = join(root, "codex-home");
-    const env = fakeCodexEnv(root);
+    const env = fakeCodexEnv(root, { nativeInstall: false });
 
     const install = runGoalMaker(["plugin", "install", "--codex-home", codexHome, "--json"], { env });
     assert.equal(install.status, 0, install.stderr || install.stdout);


### PR DESCRIPTION
> Stacked on #50. The first commit here is that PR; review only the second, or merge #50 first and this will reduce to one commit.

## Summary

The installer hand-rolled Codex's plugin store: copy the bundled tree into `plugins/cache/<marketplace>/<plugin>/<version>`, then write the `[plugins]` config entry. That re-implements internals Codex already owns, and it skipped steps Codex performs itself.

Install now calls the CLI:

```bash
codex plugin marketplace add tolibear/goalbuddy
codex plugin add goalbuddy@goalbuddy
```

The bundled-copy path stays as a fallback for a missing `codex` CLI or a failed install, which also keeps the install working offline. The report records which model ran via `install_model`.

## What the hand-rolled copy was missing

| Step Codex performs on install | Effect of skipping it |
|---|---|
| `migrate_plugin_commands` | `plugins/goalbuddy/commands/goalbuddy.md` produced **nothing** in Codex. It is harness-neutral (reads `goal-execution.md`, states the loop invariants), so migrating it gives Codex users an execution entry point, which matters because native `/goal` is gated |
| Stage into a tempdir, then rename, with rollback | A failure mid-copy could leave a half-written cache |
| `remove_old_plugin_versions` | Covered by #50; the native path now gets it for free |
| Symlink handling | Codex's installer skips symlinks; a recursive copy recreates them. No effect today (the tree has none), but the two would drift |

## Why the published marketplace rather than the npm package

A local directory is a valid marketplace source, and pointing at the npm package would have guaranteed the installed content matched the version being run. This uses `tolibear/goalbuddy` anyway, because the entry is written into the user's `config.toml` and it should be portable and match what the docs tell people to run. A path under an npx cache is machine-specific and disappears when that cache is cleared.

The consequence is that a Codex install tracks the marketplace's default branch, the same way the Claude Code plugin does. That is one distribution model rather than two.

## Notes

- Subagents still install as loose `~/.codex/agents/*.toml`. Codex plugins cannot bundle them: neither manifest format has an `agents` field, and agent roles are read only from config-layer `agents/` directories.
- `enablePluginConfig()` now runs only when the plugin is not already enabled, so the native path does not get its `config.toml` rewritten by our formatter.

## Test plan

- [x] `npm run check` passes (113 internal tests).
- [x] New coverage: the native path is used when the CLI can install, reporting `install_model: "codex-cli"` and the published marketplace source; the bundled copy is used when it cannot, with a warning, still producing a loadable cache, config, and agents.
- [x] The test double now simulates a real `codex plugin add`, so the native path is the default in tests and the fallback is exercised explicitly. That flushed out two pruning tests from #50 that had started passing through the native path where Codex prunes and our code never runs; they are now pointed at the fallback, the only place that code applies.
