### PR TITLE
feat: install GoalBuddy as a native Claude Code plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Dates are public npm publication dates. Historical entries describe the product 
 
 Release history must describe product behavior with anonymized evidence. Never include client, customer, company, donor, or private project names. Public contributor handles may appear only for attribution.
 
+## Unreleased
+
+- **Claude Code installs as a native plugin.** `npx goalbuddy --target claude` now drives `claude plugin marketplace add` and `claude plugin install --scope user` instead of copying files into `~/.claude`. The plugin serves the skill, the Scout/Judge/Worker subagents, and `/goalbuddy` from its own versioned cache.
+- **No loose-file fallback on Claude Code.** When the `claude` CLI is unavailable or the plugin install fails, the installer writes nothing, reports an `unmanaged` result, and prints the `/plugin` equivalents. A loose `~/.claude/skills/goal-prep` reached through a `~/.agents/skills` symlink used to surface a duplicate `goal-prep` in Codex alongside the plugin's `goalbuddy:goal-prep`; refusing to write it closes that leak.
+- **Non-destructive on upgrade.** This release stops writing loose files but does not delete them. Copies from an earlier version are detected and reported by install and by `doctor --target claude`. The existing `~/.claude/commands/goal.md` migration from 0.4.3 is unchanged.
+- **Updates stay opt-in, and the config is the CLI's to write.** The installer never enables marketplace auto-update, so an install cannot silently move a user to a new version. GoalBuddy does not hand-edit `settings.json` or `known_marketplaces.json`; the `claude` CLI records marketplace and enablement entries there during a normal plugin install and removes them on uninstall. `doctor` and `reset` gained `--target claude`, reading plugin state from `installed_plugins.json` and delegating removal to the `claude` CLI.
 ## 0.4.3: Restore Claude's Native `/goal` (2026-08-05)
 
 - **Claude Code keeps its native `/goal`.** GoalBuddy now installs its execution loop as `/goalbuddy`, removing the namespace collision introduced in 0.4.0.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ npx goalbuddy reset --target codex
 
 Native `codex plugin remove goalbuddy@goalbuddy` only removes the native plugin surface. GoalBuddy also owns the `goal_*.toml` agent files it installed, its Codex plugin cache, its marketplace entry, and old personal skill folders from earlier installs. Use `goalbuddy reset --target codex` when you want those GoalBuddy-owned files removed too.
 
+## Claude Code Install Model
+
+For Claude Code, the canonical install is the native plugin. `npx goalbuddy --target claude` runs the `claude` CLI for you:
+
+```bash
+claude plugin marketplace add tolibear/goalbuddy
+claude plugin install goalbuddy@goalbuddy --scope user
+```
+
+The plugin serves `/goal-prep`, the Scout/Judge/Worker subagents, and `/goalbuddy` from its own versioned cache, so a clean install writes nothing into `~/.claude/skills`, `~/.claude/agents`, or `~/.claude/commands`.
+
+There is no loose-file fallback. Without the `claude` CLI the installer reports an `unmanaged` result and prints the in-app equivalents (`/plugin marketplace add` then `/plugin install`) rather than copying files into your personal directories. That is deliberate: Codex reads standalone skills from `~/.agents/skills` and de-duplicates by `SKILL.md` path rather than by name, so a loose `~/.claude/skills/goal-prep` reached through a `~/.agents/skills` symlink shows up as a second, duplicate `goal-prep` in Codex next to the plugin's `goalbuddy:goal-prep`.
+
+Updates stay your choice. The installer never turns on marketplace auto-update, so a plugin install cannot silently move you to a new version; use `npx goalbuddy update`, or opt into auto-update yourself from `/plugin`. GoalBuddy does not hand-edit your Claude Code config: the marketplace and enablement entries that appear in `settings.json` and `known_marketplaces.json` are written by the `claude` CLI as part of a normal plugin install, and it removes them again on uninstall.
+
+To verify or remove a Claude Code install:
+
+```bash
+npx goalbuddy doctor --target claude
+npx goalbuddy reset --target claude
+```
+
+`doctor` reads plugin state straight from `installed_plugins.json`, so it works with or without the `claude` CLI on `PATH`, and it lists any loose files an earlier version left behind. `reset` delegates removal to the `claude` CLI.
+
 ## What It Creates
 
 ```text

--- a/internal/cli/goal-maker.mjs
+++ b/internal/cli/goal-maker.mjs
@@ -29,9 +29,12 @@ const legacyClaudeGoalCommandHashes = new Set([
 ]);
 const skillSource = join(packageRoot, canonicalSkillDirectory);
 const claudePluginSource = join(packageRoot, "plugins", "goalbuddy");
+const defaultMarketplaceSource = "tolibear/goalbuddy";
 const packageInfo = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
 const defaultCodexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
-const defaultClaudeHome = process.env.CLAUDE_HOME || join(homedir(), ".claude");
+// The `claude` CLI resolves its config directory from CLAUDE_CONFIG_DIR, so honor that first and
+// keep CLAUDE_HOME as the pre-existing fallback.
+const defaultClaudeHome = process.env.CLAUDE_CONFIG_DIR || process.env.CLAUDE_HOME || join(homedir(), ".claude");
 const requiredAgentFiles = [
   "goal_judge.toml",
   "goal_scout.toml",
@@ -102,7 +105,7 @@ async function main() {
       if (targetMode() === "codex") {
         installAgents();
       } else {
-        installClaudeAgents();
+        installClaudeAgentsCommand();
       }
       break;
     case "doctor":
@@ -121,11 +124,11 @@ async function main() {
         usage();
         break;
       }
-      if (targetMode() !== "codex") {
-        console.error("Reset currently supports --target codex only.");
-        process.exit(2);
+      if (targetMode() === "codex") {
+        resetCodex();
+      } else {
+        resetClaude();
       }
-      resetCodex();
       break;
     case "check-update":
     case "update-check":
@@ -304,7 +307,7 @@ Usage:
   ${canonicalCliName} update [--target claude|codex] [--claude-home <path>] [--codex-home <path>] [--json]
   ${canonicalCliName} agents [--target claude|codex] [--claude-home <path>] [--codex-home <path>] [--force]
   ${canonicalCliName} doctor [--target claude|codex] [--claude-home <path>] [--codex-home <path>] [--goal-ready]
-  ${canonicalCliName} reset --target codex [--codex-home <path>] [--json]
+  ${canonicalCliName} reset [--target claude|codex] [--claude-home <path>] [--codex-home <path>] [--json]
   ${canonicalCliName} check-update [--json]
   ${canonicalCliName} board <docs/goals/slug> [--host <host>] [--port <port>] [--once] [--json]
   ${canonicalCliName} init <slug> [--title "<Goal title>"] [--json]
@@ -318,8 +321,8 @@ Usage:
 Targets: by default, install/update prepares both Codex (~/.codex) and Claude Code (~/.claude). Use --target codex or --target claude to limit the command.
 
 Default:
-  ${canonicalCliName}                  Installs and enables Codex, then installs Claude Code skill + agents (skill surfaces /goal-prep).
-  ${canonicalCliName} --target claude  Installs ${canonicalProductName} for Claude Code (skill + agents; skill surfaces /goal-prep).
+  ${canonicalCliName}                  Installs the native Codex plugin, then the native Claude Code plugin (surfaces /goal-prep).
+  ${canonicalCliName} --target claude  Installs ${canonicalProductName} as the native Claude Code plugin (needs the claude CLI; surfaces /goal-prep).
   ${canonicalCliName} --target codex   Installs and enables the native Codex plugin.
 
 Compatibility:
@@ -389,84 +392,164 @@ function legacyClaudeGoalCommandPath() {
   return join(claudeHome(), "commands", "goal.md");
 }
 
-function installClaudeSkill({ quiet = false } = {}) {
-  const target = claudeSkillRoot();
-  if (!existsSync(skillSource)) {
-    console.error(`Skill payload not found: ${skillSource}`);
-    process.exit(1);
+function claudePluginId() {
+  return `${pluginName}@${pluginName}`;
+}
+
+function claudePluginsDir() {
+  // The `claude` CLI keeps plugin state under $CLAUDE_CODE_PLUGIN_CACHE_DIR when that is set and
+  // under <config-dir>/plugins otherwise. Match that precedence, tilde expansion included, so the
+  // reads below find the same files the CLI wrote.
+  const override = process.env.CLAUDE_CODE_PLUGIN_CACHE_DIR;
+  if (override) return override === "~" || override.startsWith("~/") ? homedir() + override.slice(1) : override;
+  return join(claudeHome(), "plugins");
+}
+
+function claudeKnownMarketplacesPath() {
+  return join(claudePluginsDir(), "known_marketplaces.json");
+}
+
+function claudeInstalledPluginsPath() {
+  return join(claudePluginsDir(), "installed_plugins.json");
+}
+
+function claudeSettingsPath() {
+  return join(claudeHome(), "settings.json");
+}
+
+function readJsonFile(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
   }
+}
 
-  const legacyTarget = legacyClaudeSkillRoot();
-  const previousMetadata = readInstallMetadata(target) || readInstallMetadata(legacyTarget);
-  const previousFingerprint = existsSync(target) ? directoryFingerprint(target, { exclude: installFingerprintExcludes() }) : "";
-
-  mkdirSync(dirname(target), { recursive: true });
-  rmSync(target, { recursive: true, force: true });
-  cpSync(skillSource, target, { recursive: true });
-  writeInstallMetadata(target, previousMetadata);
-
-  const legacyRemoved = existsSync(legacyTarget);
-  if (legacyRemoved) {
-    rmSync(legacyTarget, { recursive: true, force: true });
-    if (!quiet) console.log(`removed legacy ${legacyTarget} (skill now installs as ${canonicalSkillName})`);
+function claudeSpawnCommand(args, env) {
+  if (process.platform !== "win32") return { file: "claude", args };
+  const command = resolveWindowsCommand("claude", env);
+  if (!command) return { file: "claude", args };
+  if (/\.(?:cmd|bat)$/i.test(command)) {
+    const commandLine = [quoteWindowsCommandArg(command), ...args.map(quoteWindowsCommandArg)].join(" ");
+    return { file: commandLine, args: [], shell: true };
   }
+  return { file: command, args };
+}
 
-  const currentFingerprint = directoryFingerprint(target, { exclude: installFingerprintExcludes() });
-  const status = previousFingerprint
-    ? previousFingerprint === currentFingerprint ? "unchanged" : "updated"
-    : "installed";
-  if (!quiet) console.log(`Installed Claude Code ${canonicalProductName} skill to ${target}`);
-
+// The `claude` CLI reads its config directory from CLAUDE_CONFIG_DIR, so point it at the same home
+// this installer inspects.
+function runClaude(args) {
+  const env = { ...process.env, CLAUDE_CONFIG_DIR: claudeHome() };
+  const command = claudeSpawnCommand(args, env);
+  const result = spawnSync(command.file, command.args, {
+    encoding: "utf8",
+    env,
+    shell: command.shell || false,
+    // `marketplace add` and `install` clone from GitHub; bound the wait so a stalled network cannot
+    // hang `npx goalbuddy` indefinitely (a timeout reads as a failed call).
+    timeout: 120000,
+  });
   return {
-    status,
-    path: target,
-    previous_version: previousMetadata?.package_version || "",
-    current_version: packageInfo.version,
-    removed_legacy_skill_path: legacyRemoved ? legacyTarget : "",
+    ok: result.status === 0,
+    status: result.status,
+    stdout: result.stdout || "",
+    stderr: result.stderr || result.error?.message || "",
   };
 }
 
-function installClaudeAgents({ quiet = false } = {}) {
-  const source = join(claudePluginSource, "agents");
-  const target = claudeAgentsRoot();
-  const force = hasFlag("--force") || command === "update" || command === "install" || command === "default";
-  mkdirSync(target, { recursive: true });
+function claudeCliAvailable() {
+  return runClaude(["--version"]).ok;
+}
 
-  const results = [];
-  if (!existsSync(source)) return results;
-  for (const file of readdirSync(source)) {
-    if (!file.endsWith(".md")) continue;
-    const dest = join(target, file);
-    const sourceHash = sha256(readFileSync(join(source, file)));
-    const previousHash = existsSync(dest) ? sha256(readFileSync(dest)) : "";
-    if (existsSync(dest) && !force) {
-      if (!quiet) console.log(`skip existing ${dest} (use --force to overwrite)`);
-      results.push({ file, status: "skipped", path: dest });
-      continue;
-    }
-    cpSync(join(source, file), dest);
-    const status = previousHash ? previousHash === sourceHash ? "unchanged" : "updated" : "installed";
-    if (!quiet) console.log(`installed ${dest}`);
-    results.push({ file, status, path: dest });
+function installedClaudePlugin() {
+  const data = readJsonFile(claudeInstalledPluginsPath());
+  const records = data?.plugins?.[claudePluginId()];
+  if (!Array.isArray(records)) return null;
+  return records.find((record) => record?.scope === "user") || records[0] || null;
+}
+
+// Copies an earlier GoalBuddy version wrote directly into the personal directories. The plugin now
+// owns all of these, so they are duplicates. Skill roots are matched by GoalBuddy's own directory
+// names; the agent and command files are matched by content marker so a same-named file the user
+// wrote themselves is never reported as ours.
+function goalbuddyLooseFiles() {
+  const found = [];
+  for (const dir of [claudeSkillRoot(), legacyClaudeSkillRoot()]) {
+    if (existsSync(dir)) found.push(dir);
   }
-  return results;
+  const agentsRoot = claudeAgentsRoot();
+  const namedFiles = [
+    ...requiredClaudeAgentFiles.map((file) => join(agentsRoot, file)),
+    claudeGoalCommandPath(),
+  ];
+  for (const path of namedFiles) {
+    if (existsSync(path) && fileHasGoalbuddyMarker(path)) found.push(path);
+  }
+  return found;
+}
+
+function fileHasGoalbuddyMarker(path) {
+  try {
+    return readFileSync(path, "utf8").includes(canonicalProductName);
+  } catch {
+    return false;
+  }
+}
+
+function installClaudePlugin() {
+  const source = optionValue("--source") || defaultMarketplaceSource;
+  const manifestPath = join(claudePluginSource, ".claude-plugin", "plugin.json");
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Claude plugin manifest not found: ${manifestPath}`);
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const pluginId = claudePluginId();
+  const warnings = [];
+
+  // Deliberately unpinned. `marketplace add owner/repo@<tag>` is supported, but a stored ref makes
+  // every later `marketplace update` re-fetch that same tag, which would silently freeze anyone who
+  // turns on auto-update. Tracking the marketplace's default branch is the normal contract and keeps
+  // the update decision with the user.
+  const marketplace = runClaude(["plugin", "marketplace", "add", source]);
+  if (!marketplace.ok) {
+    throw new Error(`Failed to add Claude plugin marketplace: ${firstLine(marketplace.stderr || marketplace.stdout)}`);
+  }
+  // `marketplace add` is a noop once the clone exists, so it does not pull new commits. Refresh the
+  // local checkout so `install` and `update` see the latest release.
+  runClaude(["plugin", "marketplace", "update", pluginName]);
+
+  const previous = installedClaudePlugin();
+  const install = runClaude(["plugin", "install", pluginId, "--scope", "user"]);
+  if (!install.ok) {
+    throw new Error(`Failed to install Claude plugin: ${firstLine(install.stderr || install.stdout)}`);
+  }
+  // `install` is a noop when the plugin is already present; `update` moves an existing install to
+  // the latest release.
+  const update = runClaude(["plugin", "update", pluginId]);
+  if (!update.ok) {
+    warnings.push(`\`claude plugin update ${pluginId}\` did not complete: ${firstLine(update.stderr || update.stdout)}`);
+  }
+
+  const installedRecord = installedClaudePlugin();
+
+  return {
+    mode: "plugin",
+    installed: true,
+    target: "claude",
+    plugin: pluginId,
+    version: installedRecord?.version || manifest.version,
+    previous_version: previous?.version || "",
+    claude_home: claudeHome(),
+    marketplace_source: source,
+    install_path: installedRecord?.installPath || "",
+    update_status: update.ok ? "ok" : "failed",
+    warnings,
+  };
 }
 
 function claudeGoalCommandPath() {
   return join(claudeHome(), "commands", "goalbuddy.md");
-}
-
-function installClaudeGoalCommand({ quiet = false } = {}) {
-  const source = join(claudePluginSource, "commands", "goalbuddy.md");
-  const target = claudeGoalCommandPath();
-  if (!existsSync(source)) return { status: "missing_source", path: target };
-  const sourceHash = sha256(readFileSync(source));
-  const previousHash = existsSync(target) ? sha256(readFileSync(target)) : "";
-  mkdirSync(dirname(target), { recursive: true });
-  cpSync(source, target);
-  const status = previousHash ? previousHash === sourceHash ? "unchanged" : "updated" : "installed";
-  if (!quiet) console.log(`installed ${target}`);
-  return { status, path: target };
 }
 
 function cleanupLegacyClaudeGoalCommand({ quiet = false } = {}) {
@@ -501,31 +584,83 @@ function cleanupLegacyClaudeCommands({ quiet = false } = {}) {
   return { removed: true, path: legacyPath };
 }
 
+// GoalBuddy installs into Claude Code as a native plugin. The plugin serves the skill, the
+// Scout/Judge/Worker subagents, and the /goalbuddy command out of its own versioned cache, so this
+// installer no longer writes anything into the personal directories. When the plugin cannot be
+// installed automatically it reports `unmanaged` and prints the in-app commands rather than falling
+// back to loose copies: a loose ~/.claude/skills/goal-prep reached through a ~/.agents/skills
+// symlink surfaces a duplicate goal-prep in Codex alongside the plugin's goalbuddy:goal-prep.
 async function buildClaudeInstallReport() {
   const quiet = true;
-  const report = {
+  // Unchanged from 0.4.3: the pre-0.4.3 loose /goal command is not a plugin-owned path, and leaving
+  // it in place keeps Claude Code's native /goal shadowed.
+  const legacyCleanups = {
+    legacy_goal_command_cleanup: cleanupLegacyClaudeGoalCommand({ quiet }),
+    legacy_commands_cleanup: cleanupLegacyClaudeCommands({ quiet }),
+  };
+
+  if (claudeCliAvailable()) {
+    try {
+      const plugin = installClaudePlugin();
+      return {
+        command,
+        target: "claude",
+        mode: "plugin",
+        package: {
+          name: packageInfo.name,
+          current_version: packageInfo.version,
+          previous_version: plugin.previous_version,
+        },
+        claude_home: claudeHome(),
+        plugin,
+        ...legacyCleanups,
+        loose_files: goalbuddyLooseFiles(),
+        warnings: claudeInstallWarnings(legacyCleanups, plugin.warnings),
+      };
+    } catch (error) {
+      return buildClaudeUnmanagedReport(legacyCleanups, [
+        `Native Claude plugin install failed (${error.message}). Re-run once resolved, or from inside Claude Code run: /plugin marketplace add ${defaultMarketplaceSource} then /plugin install ${claudePluginId()}.`,
+      ]);
+    }
+  }
+
+  return buildClaudeUnmanagedReport(legacyCleanups, [
+    `claude CLI not found on PATH. ${canonicalProductName} installs into Claude Code as a native plugin: install the Claude Code CLI and re-run, or from inside Claude Code run: /plugin marketplace add ${defaultMarketplaceSource} then /plugin install ${claudePluginId()}.`,
+  ]);
+}
+
+function buildClaudeUnmanagedReport(legacyCleanups, warnings) {
+  return {
     command,
     target: "claude",
+    mode: "unmanaged",
     package: {
       name: packageInfo.name,
       current_version: packageInfo.version,
+      previous_version: "",
     },
     claude_home: claudeHome(),
-    skill: installClaudeSkill({ quiet }),
-    agents: installClaudeAgents({ quiet }),
-    goal_command: installClaudeGoalCommand({ quiet }),
-    legacy_goal_command_cleanup: cleanupLegacyClaudeGoalCommand({ quiet }),
-    legacy_commands_cleanup: cleanupLegacyClaudeCommands({ quiet }),
-    warnings: [],
+    plugin: null,
+    ...legacyCleanups,
+    loose_files: goalbuddyLooseFiles(),
+    warnings: claudeInstallWarnings(legacyCleanups, warnings),
   };
+}
 
-  report.package.previous_version = report.skill.previous_version;
-  if (report.legacy_goal_command_cleanup.preserved) {
-    report.warnings.push(
-      `Preserved ${report.legacy_goal_command_cleanup.path} because it is not GoalBuddy-authored. Claude Code's native /goal may remain shadowed until you rename or remove that file.`,
+function claudeInstallWarnings(legacyCleanups, extra = []) {
+  const warnings = [...extra];
+  if (legacyCleanups.legacy_goal_command_cleanup.preserved) {
+    warnings.push(
+      `Preserved ${legacyCleanups.legacy_goal_command_cleanup.path} because it is not GoalBuddy-authored. Claude Code's native /goal may remain shadowed until you rename or remove that file.`,
     );
   }
-  return report;
+  const looseFiles = goalbuddyLooseFiles();
+  if (looseFiles.length) {
+    warnings.push(
+      `Loose ${canonicalProductName} files from an earlier version duplicate the plugin and can surface a duplicate skill in Codex through a ~/.agents/skills symlink: ${looseFiles.join(", ")}. Remove them once the plugin is installed.`,
+    );
+  }
+  return warnings;
 }
 
 async function installClaudeAll() {
@@ -575,52 +710,93 @@ async function installEverywhere() {
   if (!report.ok) process.exit(1);
 }
 
+// Reports plugin state. The installed record is read straight from installed_plugins.json, so this
+// works with or without the `claude` CLI on PATH. Loose copies from an earlier version are listed
+// because they duplicate the plugin and leak into Codex through a ~/.agents/skills symlink.
 function doctorClaude() {
-  const skillPath = join(claudeSkillRoot(), "SKILL.md");
-  const agentsPath = claudeAgentsRoot();
-  const installed = existsSync(skillPath);
-  const agents = existsSync(agentsPath)
-    ? readdirSync(agentsPath).filter((file) => file.startsWith("goal-") && file.endsWith(".md"))
-    : [];
-  const missingAgents = requiredClaudeAgentFiles.filter((file) => !agents.includes(file));
-  const staleAgents = requiredClaudeAgentFiles.filter((file) => {
-    const installedAgent = join(agentsPath, file);
-    const bundledAgent = join(claudePluginSource, "agents", file);
-    if (!existsSync(installedAgent) || !existsSync(bundledAgent)) return false;
-    return sha256(readFileSync(installedAgent)) !== sha256(readFileSync(bundledAgent));
-  });
-  const legacyCommandPath = legacyClaudeCommandPath();
-  const legacyCommandPresent = existsSync(legacyCommandPath);
-  const legacySkillPath = legacyClaudeSkillRoot();
-  const legacySkillPresent = existsSync(legacySkillPath);
-  const goalCommandPath = claudeGoalCommandPath();
-  const goalCommandPresent = existsSync(goalCommandPath);
+  const record = installedClaudePlugin();
+  const installed = Boolean(record);
+  const known = readJsonFile(claudeKnownMarketplacesPath()) || {};
+  const settings = readJsonFile(claudeSettingsPath()) || {};
+  const autoUpdateEnabled = known?.[pluginName]?.autoUpdate === true
+    || settings?.extraKnownMarketplaces?.[pluginName]?.autoUpdate === true;
+
   const legacyGoalCommandPath = legacyClaudeGoalCommandPath();
   const legacyGoalCommandPresent = existsSync(legacyGoalCommandPath);
   const legacyGoalCommandOwned = legacyGoalCommandPresent && fileIsLegacyGoalBuddyCommand(legacyGoalCommandPath);
+  const loosePaths = goalbuddyLooseFiles();
 
   console.log(JSON.stringify({
     target: "claude",
+    mode: "plugin",
     claude_home: claudeHome(),
-    skill_installed: installed,
-    skill_path: skillPath,
-    installed_agents: agents,
-    missing_agents: missingAgents,
-    stale_agents: staleAgents,
-    goal_command_present: goalCommandPresent,
-    goal_command_path: goalCommandPath,
+    claude_cli_available: claudeCliAvailable(),
+    plugin: claudePluginId(),
+    plugin_installed: installed,
+    installed_version: record?.version || "",
+    install_path: record?.installPath || "",
+    auto_update_enabled: autoUpdateEnabled,
     native_goal_available: !legacyGoalCommandPresent,
     legacy_goal_command_present: legacyGoalCommandPresent,
     legacy_goal_command_owned: legacyGoalCommandOwned,
     legacy_goal_command_path: legacyGoalCommandPath,
-    legacy_command_present: legacyCommandPresent,
-    legacy_command_path: legacyCommandPath,
-    legacy_skill_present: legacySkillPresent,
-    legacy_skill_path: legacySkillPath,
+    loose_files: loosePaths,
   }, null, 2));
 
-  const installOk = installed && missingAgents.length === 0 && staleAgents.length === 0 && goalCommandPresent && !legacyGoalCommandPresent && !legacyCommandPresent && !legacySkillPresent;
-  process.exit(installOk ? 0 : 1);
+  process.exit(installed && !legacyGoalCommandPresent && loosePaths.length === 0 ? 0 : 1);
+}
+
+// The Claude Scout/Judge/Worker subagents ship inside the plugin, so there is nothing to install as
+// loose personal files. Point at the plugin and report any loose leftovers.
+function installClaudeAgentsCommand() {
+  const looseFiles = goalbuddyLooseFiles();
+  if (hasFlag("--json")) {
+    printJson({ target: "claude", mode: "plugin", plugin: claudePluginId(), loose_files: looseFiles });
+    return;
+  }
+  console.log(`${canonicalProductName} Claude Code subagents ship inside the plugin.`);
+  console.log(`Install or update it from inside Claude Code: /plugin install ${claudePluginId()}`);
+  if (looseFiles.length) {
+    console.log(`Loose files from an earlier version remain: ${looseFiles.join(", ")}`);
+  }
+}
+
+// The plugin bundles everything it ships, so uninstalling it is the `claude` CLI's job. Delegate to
+// `plugin uninstall` and `marketplace remove`, which manage their own settings.json and
+// known_marketplaces.json entries.
+function resetClaude() {
+  const pluginId = claudePluginId();
+  const cliActions = [];
+  if (claudeCliAvailable()) {
+    const uninstall = runClaude(["plugin", "uninstall", pluginId]);
+    cliActions.push({ action: "plugin-uninstall", ok: uninstall.ok });
+    const removeMarket = runClaude(["plugin", "marketplace", "remove", pluginName]);
+    cliActions.push({ action: "marketplace-remove", ok: removeMarket.ok });
+  }
+
+  const report = {
+    target: "claude",
+    claude_home: claudeHome(),
+    plugin: pluginId,
+    claude_cli_available: cliActions.length > 0,
+    cli_actions: cliActions,
+    loose_files: goalbuddyLooseFiles(),
+  };
+
+  if (hasFlag("--json")) {
+    printJson(report);
+    return;
+  }
+
+  console.log(`Reset ${canonicalProductName} for Claude Code`);
+  if (cliActions.length === 0) {
+    console.log(`Plugin: claude CLI not found. Remove it with: claude plugin uninstall ${pluginId} && claude plugin marketplace remove ${pluginName}`);
+  } else {
+    for (const action of cliActions) console.log(`${action.action}: ${action.ok ? "ok" : "failed"}`);
+  }
+  if (report.loose_files.length) {
+    console.log(`Loose files from an earlier version remain: ${report.loose_files.join(", ")}`);
+  }
 }
 
 function printClaudeInstallReport(report) {
@@ -631,9 +807,16 @@ function printClaudeInstallReport(report) {
   console.log("");
   console.log(`${verb} ${canonicalProductName} for Claude Code${previous}`);
   console.log("");
-  console.log(`Skill: ${report.skill.status} at ${report.skill.path}`);
-  console.log(`Agents: ${summarizeStatuses(report.agents)}`);
-  console.log(`Command: /goalbuddy ${report.goal_command.status} at ${report.goal_command.path}`);
+  if (report.mode === "plugin") {
+    console.log(`Plugin: ${report.plugin.plugin} ${report.plugin.version}`);
+    console.log(`Marketplace: ${report.plugin.marketplace_source}`);
+    console.log(`Update with: npx ${canonicalCliName} update  (or enable auto-update in /plugin)`);
+  } else {
+    console.log(`${canonicalProductName} for Claude Code installs as a native plugin.`);
+    console.log("Finish install from inside Claude Code:");
+    console.log(`  /plugin marketplace add ${defaultMarketplaceSource}`);
+    console.log(`  /plugin install ${claudePluginId()}`);
+  }
   if (report.legacy_goal_command_cleanup?.removed) {
     console.log(`Removed legacy GoalBuddy command: ${report.legacy_goal_command_cleanup.path}`);
   }
@@ -1615,10 +1798,8 @@ function printEverywhereInstallReport(report) {
 
   if (report.claude?.ok === false) {
     console.log(`Claude Code: not completed (${report.claude.error})`);
-  } else if (report.claude) {
-    console.log(`Claude Code: skill ${report.claude.skill.status} at ${report.claude.skill.path}`);
-    console.log(`Claude Code agents: ${summarizeStatuses(report.claude.agents)}`);
-    console.log(`Claude Code command: /goalbuddy ${report.claude.goal_command.status} at ${report.claude.goal_command.path}`);
+  } else if (report.claude?.mode === "plugin") {
+    console.log(`Claude Code: plugin ${report.claude.plugin.version} installed`);
     if (report.claude.legacy_goal_command_cleanup?.removed) {
       console.log(`Claude Code: removed legacy GoalBuddy command at ${report.claude.legacy_goal_command_cleanup.path}`);
     }
@@ -1626,6 +1807,9 @@ function printEverywhereInstallReport(report) {
       console.log(`Claude Code: removed legacy command at ${report.claude.legacy_commands_cleanup.path}`);
     }
     for (const warning of report.claude.warnings || []) console.log(`Claude Code warning: ${warning}`);
+  } else if (report.claude) {
+    console.log("Claude Code: native plugin not installed (needs the claude CLI or /plugin)");
+    for (const warning of report.claude.warnings || []) console.log(`  Note: ${warning}`);
   }
 
   if (report.errors.length) {
@@ -1636,8 +1820,12 @@ function printEverywhereInstallReport(report) {
 
   console.log("");
   console.log("Next:");
-  console.log(`  Restart Codex, then use: $${canonicalSkillName}`);
-  console.log("  Restart Claude Code, then run: /goal-prep");
+  console.log(`  Restart Codex, then use: ${canonicalSkillName}`);
+  if (report.claude?.mode === "plugin") {
+    console.log("  Restart Claude Code, then run: /goal-prep");
+  } else if (report.claude) {
+    console.log(`  Finish Claude Code: /plugin marketplace add ${defaultMarketplaceSource} then /plugin install ${claudePluginId()}`);
+  }
 }
 
 function summarizeStatuses(items) {

--- a/internal/test/goal-maker-cli.test.mjs
+++ b/internal/test/goal-maker-cli.test.mjs
@@ -91,6 +91,56 @@ function fakeCodexEnv(root, options = {}) {
   };
 }
 
+// Writes a fake `claude` into the shared root/bin so tests are deterministic regardless of
+// whether the host has a real claude CLI. `available: false` makes `claude --version` fail so
+// the installer takes the unmanaged (plugin-only, no loose files) path.
+// Options: `available` gates `--version`; `installFails` makes `plugin install` exit non-zero;
+// `recordTo` appends each invocation's argv to a log (assert exact commands); `installVersion`
+// makes `plugin install` write a realistic installed_plugins.json so the upgrade path is testable.
+// The win32 stub is minimal (CI is linux); recordTo/installVersion are posix-only.
+function fakeClaudeBin(root, { available = true, installFails = false, installVersion = null, recordTo = null } = {}) {
+  const bin = join(root, "bin");
+  mkdirSync(bin, { recursive: true });
+  if (process.platform === "win32") {
+    const lines = ["@echo off"];
+    lines.push(available ? "if \"%~1\"==\"--version\" echo 2.1.214 (Claude Code)& exit /b 0" : "if \"%~1\"==\"--version\" exit /b 1");
+    if (installFails) lines.push("if \"%~1\"==\"plugin\" if \"%~2\"==\"install\" exit /b 1");
+    lines.push("exit /b 0", "");
+    writeFileSync(join(bin, "claude.cmd"), lines.join("\r\n"));
+    return bin;
+  }
+  const lines = ["#!/bin/sh"];
+  if (recordTo) lines.push(`printf '%s\\n' "$*" >> ${JSON.stringify(recordTo)}`);
+  lines.push(available
+    ? "if [ \"$1\" = \"--version\" ]; then echo \"2.1.214 (Claude Code)\"; exit 0; fi"
+    : "if [ \"$1\" = \"--version\" ]; then exit 1; fi");
+  if (installFails) {
+    lines.push("if [ \"$1\" = \"plugin\" ] && [ \"$2\" = \"install\" ]; then echo \"install failed\" 1>&2; exit 1; fi");
+  } else if (installVersion) {
+    lines.push("if [ \"$1\" = \"plugin\" ] && [ \"$2\" = \"install\" ]; then");
+    lines.push(`  cache="$CLAUDE_CONFIG_DIR/plugins/cache/goalbuddy/goalbuddy/${installVersion}"`);
+    lines.push("  mkdir -p \"$cache\"");
+    lines.push(`  printf '{"plugins":{"goalbuddy@goalbuddy":[{"scope":"user","installPath":"%s","version":"${installVersion}"}]}}\\n' "$cache" > "$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json"`);
+    lines.push("  exit 0");
+    lines.push("fi");
+  }
+  lines.push("exit 0", "");
+  const path = join(bin, "claude");
+  writeFileSync(path, lines.join("\n"));
+  chmodSync(path, 0o755);
+  return bin;
+}
+
+function absentClaudeEnv(root, base = process.env) {
+  const bin = fakeClaudeBin(root, { available: false });
+  return { ...base, PATH: `${bin}${delimiter}${base.PATH}` };
+}
+
+function nativeClaudeEnv(root, base = process.env) {
+  const bin = fakeClaudeBin(root, { available: true });
+  return { ...base, PATH: `${bin}${delimiter}${base.PATH}` };
+}
+
 test("doctor fails when a required bundled agent is missing", () => {
   const root = mkdtempSync(join(tmpdir(), "goal-maker-cli-test-"));
   try {
@@ -1155,7 +1205,7 @@ test("default command installs Codex and Claude Code when both homes are provide
   try {
     const codexHome = join(root, "codex-home");
     const claudeHome = join(root, "claude-home");
-    const env = fakeCodexEnv(root);
+    const env = nativeClaudeEnv(root, fakeCodexEnv(root));
 
     const install = runGoalMaker(["--codex-home", codexHome, "--claude-home", claudeHome, "--json"], { env });
     assert.equal(install.status, 0, install.stderr || install.stdout);
@@ -1163,11 +1213,14 @@ test("default command installs Codex and Claude Code when both homes are provide
     const report = JSON.parse(install.stdout);
     assert.equal(report.ok, true);
     assert.equal(report.codex.installed, true);
-    assert.equal(report.claude.skill.status, "installed");
+    assert.equal(report.claude.mode, "plugin");
+    assert.equal(report.claude.plugin.plugin, "goalbuddy@goalbuddy");
     assert.equal(existsSync(join(codexHome, "config.toml")), true);
-    assert.equal(existsSync(join(claudeHome, "skills", "goal-prep", "SKILL.md")), true);
-    assert.equal(existsSync(join(claudeHome, "agents", "goal-worker.md")), true);
-    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), true);
+    // the plugin serves the skill, subagents, and /goalbuddy from its own cache, so nothing
+    // is written into the personal directories
+    assert.equal(existsSync(join(claudeHome, "skills", "goal-prep")), false);
+    assert.equal(existsSync(join(claudeHome, "agents", "goal-worker.md")), false);
+    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), false);
     assert.equal(existsSync(join(claudeHome, "commands", "goal.md")), false);
     assert.equal(existsSync(join(claudeHome, "commands", "goal-prep.md")), false);
   } finally {
@@ -1199,18 +1252,17 @@ test("update refreshes Codex plugin and Claude Code install together", () => {
   try {
     const codexHome = join(root, "codex-home");
     const claudeHome = join(root, "claude-home");
-    const env = fakeCodexEnv(root);
+    const env = nativeClaudeEnv(root, fakeCodexEnv(root));
 
     const install = runGoalMaker(["--codex-home", codexHome, "--claude-home", claudeHome, "--json"], { env });
     assert.equal(install.status, 0, install.stderr || install.stdout);
-
-    writeFileSync(join(claudeHome, "agents", "goal-worker.md"), "stale\n");
 
     const update = runGoalMaker(["update", "--codex-home", codexHome, "--claude-home", claudeHome, "--json"], { env });
     assert.equal(update.status, 0, update.stderr || update.stdout);
     const report = JSON.parse(update.stdout);
     assert.equal(report.ok, true);
-    assert.equal(report.claude.agents.find((agent) => agent.file === "goal-worker.md").status, "updated");
+    assert.equal(report.codex.installed, true);
+    assert.equal(report.claude.mode, "plugin");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1363,42 +1415,46 @@ test("judge receipt contract includes worker_package in every surface", () => {
   assert.deepEqual(mdSchema.worker_package, tomlSchema.worker_package);
 });
 
-test("installs the Claude skill as goal-prep and migrates the legacy directory", () => {
+test("a loose skill directory from an earlier version is reported, not silently replaced", () => {
   const root = mkdtempSync(join(tmpdir(), "goalbuddy-skill-rename-"));
   try {
     const claudeHome = join(root, "claude");
-    mkdirSync(join(claudeHome, "skills", "goalbuddy"), { recursive: true });
-    writeFileSync(join(claudeHome, "skills", "goalbuddy", "SKILL.md"), "legacy\n");
-    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"]);
-    assert.equal(result.status, 0, result.stderr);
-    assert.equal(existsSync(join(claudeHome, "skills", "goal-prep", "SKILL.md")), true);
-    assert.equal(existsSync(join(claudeHome, "skills", "goalbuddy")), false);
+    const looseSkill = join(claudeHome, "skills", "goalbuddy");
+    mkdirSync(looseSkill, { recursive: true });
+    writeFileSync(join(looseSkill, "SKILL.md"), "legacy\n");
 
-    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome]);
-    assert.equal(doctor.status, 0, doctor.stderr || doctor.stdout);
-    const report = JSON.parse(doctor.stdout);
-    assert.equal(report.legacy_skill_present, false);
-    assert.match(report.skill_path, pathSuffixPattern("skills", "goal-prep", "SKILL.md"));
+    const env = nativeClaudeEnv(root);
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.mode, "plugin");
+    // this change installs the plugin; it does not delete anything an earlier version wrote
+    assert.equal(existsSync(looseSkill), true);
+    assert.ok(report.loose_files.includes(looseSkill), JSON.stringify(report.loose_files));
+    assert.match(report.warnings.join("\n"), /duplicate the plugin/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test("installs /goalbuddy without shadowing Claude Code's native /goal", () => {
+test("the plugin serves /goalbuddy and leaves Claude Code's native /goal alone", () => {
   const root = mkdtempSync(join(tmpdir(), "goalbuddy-goal-command-"));
   try {
     const claudeHome = join(root, "claude");
-    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"]);
+    const env = nativeClaudeEnv(root);
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
     assert.equal(result.status, 0, result.stderr);
-    const command = readFileSync(join(claudeHome, "commands", "goalbuddy.md"), "utf8");
+
+    // the command ships inside the plugin, so no personal-directory copy is written
+    const command = readFileSync("plugins/goalbuddy/commands/goalbuddy.md", "utf8");
     assert.match(command, /GoalBuddy/);
     assert.match(command, /state\.yaml/);
+    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), false);
     assert.equal(existsSync(join(claudeHome, "commands", "goal.md")), false);
 
-    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome]);
-    assert.equal(doctor.status, 0, doctor.stderr || doctor.stdout);
+    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome], { env });
     const report = JSON.parse(doctor.stdout);
-    assert.equal(report.goal_command_present, true);
     assert.equal(report.native_goal_available, true);
     assert.equal(report.legacy_goal_command_present, false);
   } finally {
@@ -1416,12 +1472,14 @@ test("install removes an old GoalBuddy-owned /goal command", () => {
       .replace("Run the GoalBuddy execution loop.\n", "Run the GoalBuddy `/goal` execution loop.\n");
     writeFileSync(legacyCommand, legacyBody);
 
-    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"]);
+    const env = nativeClaudeEnv(root);
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
     assert.equal(result.status, 0, result.stderr || result.stdout);
     const report = JSON.parse(result.stdout);
     assert.equal(report.legacy_goal_command_cleanup.removed, true);
     assert.equal(existsSync(legacyCommand), false);
-    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), true);
+    // /goalbuddy now ships inside the plugin, so no personal-directory copy is written
+    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), false);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -1435,14 +1493,15 @@ test("install preserves a user-authored /goal command and doctor reports the col
     mkdirSync(join(claudeHome, "commands"), { recursive: true });
     writeFileSync(legacyCommand, "My private GoalBuddy helper.\n");
 
-    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"]);
+    const env = nativeClaudeEnv(root);
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
     assert.equal(result.status, 0, result.stderr || result.stdout);
     const report = JSON.parse(result.stdout);
     assert.equal(report.legacy_goal_command_cleanup.preserved, true);
     assert.match(report.warnings.join("\n"), /native \/goal may remain shadowed/);
     assert.equal(readFileSync(legacyCommand, "utf8"), "My private GoalBuddy helper.\n");
 
-    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome]);
+    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome], { env });
     assert.equal(doctor.status, 1, doctor.stderr || doctor.stdout);
     const doctorReport = JSON.parse(doctor.stdout);
     assert.equal(doctorReport.native_goal_available, false);
@@ -1472,10 +1531,256 @@ test("repeated flags take the last value", () => {
   try {
     const first = join(root, "first");
     const second = join(root, "second");
-    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", first, "--claude-home", second, "--json"]);
+    const env = nativeClaudeEnv(root);
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", first, "--claude-home", second, "--json"], { env });
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(existsSync(join(second, "skills", "goal-prep", "SKILL.md")), true);
-    assert.equal(existsSync(join(first, "skills")), false);
+    assert.equal(JSON.parse(result.stdout).claude_home, second);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("native Claude install sends the expected plugin command sequence", { skip: process.platform === "win32" }, () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-native-"));
+  try {
+    const claudeHome = join(root, "claude");
+    const log = join(root, "claude-calls.log");
+    const bin = fakeClaudeBin(root, { available: true, recordTo: log, installVersion: packageVersion });
+    const env = { ...process.env, PATH: `${bin}${delimiter}${process.env.PATH}` };
+
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.mode, "plugin");
+    assert.equal(report.plugin.plugin, "goalbuddy@goalbuddy");
+    assert.equal(report.plugin.version, packageVersion);
+
+    const calls = readFileSync(log, "utf8");
+    assert.match(calls, /plugin marketplace add tolibear\/goalbuddy/);
+    assert.match(calls, /plugin marketplace update goalbuddy/);
+    assert.match(calls, /plugin install goalbuddy@goalbuddy --scope user/);
+    assert.match(calls, /plugin update goalbuddy@goalbuddy/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("does not write loose Claude files when the claude CLI is absent", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-unmanaged-"));
+  try {
+    const claudeHome = join(root, "claude");
+    const env = absentClaudeEnv(root);
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.mode, "unmanaged");
+    assert.equal(report.plugin, null);
+    assert.match(report.warnings.join("\n"), /claude CLI not found on PATH/);
+    // no loose fallback: a loose skill would surface a duplicate goal-prep in Codex
+    assert.equal(existsSync(join(claudeHome, "skills")), false);
+    assert.equal(existsSync(join(claudeHome, "agents")), false);
+    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reports unmanaged and preserves a pre-existing loose install when the plugin install fails", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-install-fail-"));
+  try {
+    const claudeHome = join(root, "claude");
+    const looseSkill = join(claudeHome, "skills", "goal-prep");
+    mkdirSync(looseSkill, { recursive: true });
+    writeFileSync(join(looseSkill, "SKILL.md"), "GoalBuddy Goal Prep\n");
+
+    const bin = fakeClaudeBin(root, { available: true, installFails: true });
+    const env = { ...process.env, PATH: `${bin}${delimiter}${process.env.PATH}` };
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.mode, "unmanaged");
+    assert.match(report.warnings.join("\n"), /Native Claude plugin install failed/);
+    // a failed install must never destroy a working setup it cannot replace
+    assert.equal(existsSync(join(looseSkill, "SKILL.md")), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("native Claude install does not modify the user's settings.json", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-settings-"));
+  try {
+    const claudeHome = join(root, "claude");
+    mkdirSync(claudeHome, { recursive: true });
+    const settingsPath = join(claudeHome, "settings.json");
+    const original = `${JSON.stringify({ theme: "dark" }, null, 2)}\n`;
+    writeFileSync(settingsPath, original);
+
+    const env = nativeClaudeEnv(root);
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(readFileSync(settingsPath, "utf8"), original);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("doctor --target claude reports the plugin without the claude CLI on PATH", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-doctor-"));
+  try {
+    const claudeHome = join(root, "claude");
+    const pluginsDir = join(claudeHome, "plugins");
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, "installed_plugins.json"), JSON.stringify({
+      plugins: { "goalbuddy@goalbuddy": [{ scope: "user", installPath: join(pluginsDir, "cache"), version: packageVersion }] },
+    }));
+
+    const env = absentClaudeEnv(root);
+    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome], { env });
+    // the installed record comes from installed_plugins.json, so doctor works with no CLI
+    assert.equal(doctor.status, 0, doctor.stderr || doctor.stdout);
+    const report = JSON.parse(doctor.stdout);
+    assert.equal(report.plugin_installed, true);
+    assert.equal(report.claude_cli_available, false);
+    assert.deepEqual(report.loose_files, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("doctor --target claude honors CLAUDE_CODE_PLUGIN_CACHE_DIR", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-plugin-cache-dir-"));
+  try {
+    const claudeHome = join(root, "claude");
+    // the claude CLI stores plugin state here instead of <claude-home>/plugins when this is set
+    const cacheDir = join(root, "custom-plugin-cache");
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, "installed_plugins.json"), JSON.stringify({
+      plugins: { "goalbuddy@goalbuddy": [{ scope: "user", installPath: join(cacheDir, "cache"), version: packageVersion }] },
+    }));
+
+    const env = { ...absentClaudeEnv(root), CLAUDE_CODE_PLUGIN_CACHE_DIR: cacheDir };
+    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome], { env });
+    assert.equal(doctor.status, 0, doctor.stderr || doctor.stdout);
+    assert.equal(JSON.parse(doctor.stdout).installed_version, packageVersion);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("doctor --target claude fails and lists loose GoalBuddy files when present", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-doctor-loose-"));
+  try {
+    const claudeHome = join(root, "claude");
+    const pluginsDir = join(claudeHome, "plugins");
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, "installed_plugins.json"), JSON.stringify({
+      plugins: { "goalbuddy@goalbuddy": [{ scope: "user", installPath: join(pluginsDir, "cache"), version: packageVersion }] },
+    }));
+    mkdirSync(join(claudeHome, "agents"), { recursive: true });
+    const looseAgent = join(claudeHome, "agents", "goal-scout.md");
+    writeFileSync(looseAgent, "GoalBuddy Scout agent\n");
+
+    const env = nativeClaudeEnv(root);
+    const doctor = runGoalMaker(["doctor", "--target", "claude", "--claude-home", claudeHome], { env });
+    assert.equal(doctor.status, 1, doctor.stdout);
+    assert.ok(JSON.parse(doctor.stdout).loose_files.includes(looseAgent));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("loose-file detection spares a user's own same-named files", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-provenance-"));
+  try {
+    const claudeHome = join(root, "claude");
+    mkdirSync(join(claudeHome, "agents"), { recursive: true });
+    const userAgent = join(claudeHome, "agents", "goal-scout.md");
+    writeFileSync(userAgent, "My own scout agent, nothing to do with the product.\n");
+
+    const env = nativeClaudeEnv(root);
+    const result = runGoalMaker(["install", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    // no GoalBuddy marker, so it is not ours to claim
+    assert.deepEqual(JSON.parse(result.stdout).loose_files, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("agents --target claude points at the plugin instead of writing files", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-agents-"));
+  try {
+    const claudeHome = join(root, "claude");
+    const env = nativeClaudeEnv(root);
+    const result = runGoalMaker(["agents", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.mode, "plugin");
+    assert.equal(report.plugin, "goalbuddy@goalbuddy");
+    assert.equal(existsSync(join(claudeHome, "agents")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reset --target claude delegates to the CLI and never hand-edits config", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-claude-reset-"));
+  try {
+    const claudeHome = join(root, "claude");
+    mkdirSync(claudeHome, { recursive: true });
+    const settingsPath = join(claudeHome, "settings.json");
+    const original = `${JSON.stringify({ theme: "dark" }, null, 2)}\n`;
+    writeFileSync(settingsPath, original);
+
+    const log = join(root, "claude-calls.log");
+    const bin = fakeClaudeBin(root, { available: true, recordTo: log });
+    const env = { ...process.env, PATH: `${bin}${delimiter}${process.env.PATH}` };
+
+    const result = runGoalMaker(["reset", "--target", "claude", "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const calls = readFileSync(log, "utf8");
+    assert.match(calls, /plugin uninstall goalbuddy@goalbuddy/);
+    assert.match(calls, /plugin marketplace remove goalbuddy/);
+    assert.equal(readFileSync(settingsPath, "utf8"), original);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("install everywhere still installs Codex when the claude CLI is absent", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-everywhere-"));
+  try {
+    const codexHome = join(root, "codex-home");
+    const claudeHome = join(root, "claude-home");
+    const env = absentClaudeEnv(root, fakeCodexEnv(root));
+
+    const result = runGoalMaker(["--codex-home", codexHome, "--claude-home", claudeHome, "--json"], { env });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.codex.installed, true);
+    assert.equal(report.claude.mode, "unmanaged");
+    assert.equal(existsSync(join(claudeHome, "skills")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("claude home honors CLAUDE_CONFIG_DIR when no --claude-home is given", () => {
+  const root = mkdtempSync(join(tmpdir(), "goalbuddy-config-dir-"));
+  try {
+    const configDir = join(root, "config-claude");
+    const bin = fakeClaudeBin(root, { available: false });
+    const env = { ...process.env, CLAUDE_CONFIG_DIR: configDir, PATH: `${bin}${delimiter}${process.env.PATH}` };
+    delete env.CLAUDE_HOME;
+    const doctor = runGoalMaker(["doctor", "--target", "claude"], { env });
+    assert.equal(JSON.parse(doctor.stdout).claude_home, configDir);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/internal/test/package-files.test.mjs
+++ b/internal/test/package-files.test.mjs
@@ -55,7 +55,7 @@ test("packed canonical and plugin skill trees stay complete and aligned", () => 
   assert.deepEqual(canonicalFiles, pluginFiles);
 });
 
-test("the packed npm artifact installs the Claude contract and role agents", () => {
+test("the packed npm artifact ships the Claude plugin contract and role agents", () => {
   const root = mkdtempSync(join(tmpdir(), "goalbuddy-packed-install-"));
   try {
     const pack = runNpm(["pack", "--json", "--pack-destination", root]);
@@ -73,35 +73,23 @@ test("the packed npm artifact installs the Claude contract and role agents", () 
     ]);
     assert.equal(install.status, 0, install.stderr || install.stdout);
 
+    // Claude Code installs GoalBuddy as a native plugin, so what matters is that the published
+    // artifact carries a complete plugin tree for the `claude` CLI to install from.
     const extractedRoot = join(packageRoot, "node_modules", "goalbuddy");
-    const claudeHome = join(root, "claude-home");
-    const cli = spawnSync(process.execPath, [
-      join(extractedRoot, "internal", "cli", "goal-maker.mjs"),
-      "install",
-      "--target",
-      "claude",
-      "--claude-home",
-      claudeHome,
-      "--json",
-    ], {
-      encoding: "utf8",
-      env: { ...process.env, GOALBUDDY_SKIP_POSTINSTALL: "1" },
-    });
-    assert.equal(cli.status, 0, cli.stderr || cli.stdout);
-    const report = JSON.parse(cli.stdout);
-    assert.equal(report.skill.status, "installed");
-    assert.deepEqual(
-      report.agents.map((agent) => agent.file).sort(),
-      ["goal-judge.md", "goal-scout.md", "goal-worker.md"],
-    );
-    assert.equal(existsSync(join(claudeHome, "commands", "goalbuddy.md")), true);
-    assert.equal(existsSync(join(claudeHome, "commands", "goal.md")), false);
+    const pluginRoot = join(extractedRoot, "plugins", "goalbuddy");
 
-    const installedContract = join(claudeHome, "skills", "goal-prep", "references", "goal-execution.md");
-    assert.equal(existsSync(installedContract), true);
-    assert.match(readFileSync(installedContract, "utf8"), /governs Codex `\/goal` and Claude Code `\/goalbuddy` runs/);
+    const manifest = JSON.parse(readFileSync(join(pluginRoot, ".claude-plugin", "plugin.json"), "utf8"));
+    assert.equal(manifest.name, "goalbuddy");
+    assert.equal(manifest.version, JSON.parse(readFileSync(join(extractedRoot, "package.json"), "utf8")).version);
+
+    assert.equal(existsSync(join(pluginRoot, "commands", "goalbuddy.md")), true);
+    assert.equal(existsSync(join(pluginRoot, "commands", "goal.md")), false);
+
+    const packedContract = join(pluginRoot, "skills", "goal-prep", "references", "goal-execution.md");
+    assert.equal(existsSync(packedContract), true);
+    assert.match(readFileSync(packedContract, "utf8"), /governs Codex `\/goal` and Claude Code `\/goalbuddy` runs/);
     for (const file of ["goal-judge.md", "goal-scout.md", "goal-worker.md"]) {
-      assert.equal(existsSync(join(claudeHome, "agents", file)), true);
+      assert.equal(existsSync(join(pluginRoot, "agents", file)), true);
     }
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
Replaces #38, rebuilt against current `main` and scoped down as you asked.

## Summary

`npx goalbuddy --target claude` installs GoalBuddy on Claude Code as a **native plugin**, driving the `claude` CLI:

```bash
claude plugin marketplace add tolibear/goalbuddy
claude plugin install goalbuddy@goalbuddy --scope user
```

The plugin already ships in this repo; this change makes the installer use it. It serves the `goal-prep` skill, the Scout/Judge/Worker subagents, and `/goalbuddy` from its own versioned cache, so a clean install writes nothing into `~/.claude/skills`, `~/.claude/agents`, or `~/.claude/commands`.

There is no loose-file fallback. When the `claude` CLI is unavailable or the plugin install fails, the installer writes nothing, reports an `unmanaged` result, and prints the in-app equivalents.

`doctor` and `reset` gained `--target claude`. `doctor` reads plugin state from `installed_plugins.json`, so it works with or without the CLI on `PATH`, and it resolves the plugin store from `CLAUDE_CODE_PLUGIN_CACHE_DIR` when that override is set. `reset` delegates removal to the CLI.

## What changed since #38

| Your note | This PR |
|---|---|
| Four changes behind, conflicts with `main` | Rebuilt on current `main`; no conflicts |
| Still installs `/goal` | Uses `/goalbuddy` throughout; the 0.4.3 migration and its hash-ownership check are carried over untouched |
| Migration bundled with the install model | **This PR deletes nothing.** Loose files are detected and reported only |
| No completed smoke test | Done against a throwaway `--claude-home`; transcript below |

Rebuilding surfaced something useful: `main` already ships the complete Claude plugin contract (marketplace manifest, plugin manifest, plugin tree). It simply never installed through it, so this PR is much smaller than #38.

## Why plugin-only

Codex reads standalone skills from `~/.agents/skills` and de-duplicates by the canonicalized `SKILL.md` path rather than by name. A loose `~/.claude/skills/goal-prep` reached through a `~/.agents/skills` symlink therefore resolves to a different path **and** a different name than the plugin's copy, so both survive and Codex shows a duplicate Goal Prep next to `goalbuddy:goal-prep`. Not writing the loose file closes that at the source.

Verified against current `codex-rs`: de-duplication is still by path in `core-skills/src/root_loader.rs`, and Codex carries a regression test asserting that two same-named skills from different roots both survive.

## Migration is deliberately out of scope

This change stops writing loose files but removes none. Copies from an earlier version are reported by install and by `doctor --target claude`. Removing them is a separate change so the destructive path can be reviewed on its own, which is what you asked for.

The existing `~/.claude/commands/goal.md` migration from 0.4.3 is untouched, hash-based ownership check included.

## Updates and config

The installer never enables marketplace auto-update, so an install cannot silently move a user to a new version. GoalBuddy does not hand-edit `settings.json` or `known_marketplaces.json`; the `claude` CLI writes marketplace and enablement entries there during a normal plugin install and removes them on uninstall. The smoke test below confirms both.

One consequence worth stating plainly: because the plugin installs from the marketplace, Claude Code tracks the marketplace's default branch. Pinning the marketplace to a release tag would freeze `marketplace update` on that tag permanently, which would silently strand anyone who turns on auto-update, so this does not pin. If you would rather the plugin never serve unreleased commits, a release branch is the mechanism that keeps auto-update working.

## Test plan

- [x] `npm run check` passes (121 internal tests). The local-board tests fail only in a sandbox without loopback networking; that suite is unchanged by this PR.
- [x] Live smoke test against a throwaway `--claude-home` with `claude` 2.1.222:
  - `doctor` before install: exit 1, not installed
  - `install --target claude`: exit 0, plugin at `plugins/cache/goalbuddy/goalbuddy/0.4.3`
  - on disk: `skills/`, `agents/`, `commands/` all absent; plugin cache serves the skill, `/goalbuddy`, and all three subagents
  - `doctor` after: exit 0, `auto_update_enabled: false`
  - `reset --target claude`: uninstall and marketplace remove both ok, then `doctor` reports not installed
- [x] New coverage: the exact plugin command sequence, `unmanaged` with no loose files when the CLI is absent, a pre-existing loose install preserved when `plugin install` fails, loose-file detection sparing a user's own same-named files, `agents --target claude` pointing at the plugin, `doctor` with and without the CLI, `CLAUDE_CODE_PLUGIN_CACHE_DIR` and `CLAUDE_CONFIG_DIR` resolution, `settings.json` left untouched, and `reset` delegating to the CLI.
