### PR TITLE
test: remove client-specific fixtures

### DIFF
--- a/goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
+++ b/goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
@@ -713,7 +713,7 @@ test("unregistered board paths explain hub reuse instead of stale-port cleanup",
     const server = await startBoardServer({ goalDir, host: "127.0.0.1", port: 0 });
     try {
       const baseUrl = new URL(server.url).origin;
-      const missingResponse = await fetch(`${baseUrl}/rinova-client-revision-redesign/`);
+      const missingResponse = await fetch(`${baseUrl}/unregistered-example-board/`);
       assert.equal(missingResponse.status, 404);
       const message = await missingResponse.text();
       assert.match(message, /board path is not registered/i);

--- a/internal/test/package-files.test.mjs
+++ b/internal/test/package-files.test.mjs
@@ -15,7 +15,6 @@ test("release history stays in one running changelog", () => {
   assert.match(changelog, /single, running release history/);
   assert.match(changelog, /Do not create separate versioned changelog files/);
   assert.match(changelog, /Never include client, customer, company, donor, or private project names/);
-  assert.doesNotMatch(changelog, /FL Donate/i);
 
   for (const version of [
     "0.4.3", "0.4.2", "0.4.1", "0.4.0",

--- a/plugins/goalbuddy/skills/goal-prep/surfaces/local-goal-board/test/local-goal-board.test.mjs
+++ b/plugins/goalbuddy/skills/goal-prep/surfaces/local-goal-board/test/local-goal-board.test.mjs
@@ -713,7 +713,7 @@ test("unregistered board paths explain hub reuse instead of stale-port cleanup",
     const server = await startBoardServer({ goalDir, host: "127.0.0.1", port: 0 });
     try {
       const baseUrl = new URL(server.url).origin;
-      const missingResponse = await fetch(`${baseUrl}/rinova-client-revision-redesign/`);
+      const missingResponse = await fetch(`${baseUrl}/unregistered-example-board/`);
       assert.equal(missingResponse.status, 404);
       const message = await missingResponse.text();
       assert.match(message, /board path is not registered/i);


### PR DESCRIPTION
## What changed

- replaced a client-specific local-board test slug with a neutral example
- synchronized the canonical GoalBuddy skill into its plugin mirror
- removed a regression assertion that embedded a private project name

## Why

Public source fixtures should follow the same anonymization rule as the running changelog and GitHub Releases.

## Validation

- `git diff --check`
- `npm run check` (133 passed)
- repository-wide exact identifier scan returned zero matches