### PR TITLE
Update GoalBuddy GitHub namespace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "goalbuddy",
   "owner": {
-    "name": "tolibear",
+    "name": "tolimarchuk",
     "email": "support@tolibear.com"
   },
   "description": "GoalBuddy /goal-prep skill plus Scout/Judge/Worker subagents for pressured /goal runs.",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for improving `goalbuddy`.
 Clone the repo and run the checks:
 
 ```bash
-git clone https://github.com/tolibear/goalbuddy.git
+git clone https://github.com/tolimarchuk/goalbuddy.git
 cd goalbuddy
 npm run check
 ```

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Multiple local boards reuse one readable `goalbuddy.localhost` hub with an in-he
 
 Custom external integrations should be built as ordinary repo work with a concrete implementation plan, not installed from a GoalBuddy catalog.
 
-See the [running changelog](CHANGELOG.md) for the complete release history. The latest published snapshot is [GoalBuddy 0.4.3: Restore Claude's Native /goal](https://github.com/tolibear/goalbuddy/releases/tag/v0.4.3).
+See the [running changelog](CHANGELOG.md) for the complete release history. The latest published snapshot is [GoalBuddy 0.4.3: Restore Claude's Native /goal](https://github.com/tolimarchuk/goalbuddy/releases/tag/v0.4.3).
 
 <p align="center">
   <img src="internal/assets/goalbuddy-live-board.jpg" alt="GoalBuddy local live board open next to Codex while Scout, Judge, and Worker tasks populate." width="100%">
@@ -202,11 +202,11 @@ For release process details, see [docs/releases](docs/releases/README.md).
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=tolibear%2Fgoalbuddy&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=tolimarchuk%2Fgoalbuddy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tolibear/goalbuddy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tolibear/goalbuddy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tolibear/goalbuddy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tolimarchuk/goalbuddy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tolimarchuk/goalbuddy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tolimarchuk/goalbuddy&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -13,7 +13,7 @@ GoalBuddy publishes the `goalbuddy` npm package from GitHub Actions using npm tr
 Configure this on npmjs.com for the `goalbuddy` package:
 
 - Publisher: GitHub Actions
-- GitHub owner/user: `tolibear`
+- GitHub owner/user: `tolimarchuk`
 - Repository: `goalbuddy`
 - Workflow filename: `npm-publish.yml`
 - Package: `goalbuddy`
@@ -28,7 +28,7 @@ Or configure the same trust relationship from the npm CLI:
 
 ```bash
 npx --yes npm@^11.15.0 trust github goalbuddy \
-  --repo tolibear/goalbuddy \
+  --repo tolimarchuk/goalbuddy \
   --file npm-publish.yml \
   --allow-publish \
   --yes

--- a/goalbuddy/surfaces/local-goal-board/scripts/lib/goal-board.mjs
+++ b/goalbuddy/surfaces/local-goal-board/scripts/lib/goal-board.mjs
@@ -783,7 +783,7 @@ function boardHtml() {
       </nav>
     </div>
     <div class="header-tools">
-      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+      <a class="github-stars" href="https://github.com/tolimarchuk/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
         <span id="github-stars">Stars</span>
       </a>
@@ -2069,7 +2069,7 @@ function formatStars(count) {
 async function loadGithubStars() {
   if (!githubStarsEl) return;
   try {
-    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+    const response = await fetch("https://api.github.com/repos/tolimarchuk/goalbuddy", {
       headers: { Accept: "application/vnd.github+json" },
     });
     if (!response.ok) throw new Error("GitHub API unavailable");

--- a/goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
+++ b/goalbuddy/surfaces/local-goal-board/test/local-goal-board.test.mjs
@@ -336,7 +336,7 @@ test("writes a minimal GoalBuddy web app into the goal directory", () => {
   assert.match(js, /new EventSource\("\.\/events"\)/);
   assert.match(js, /fetch\("\.\.\/api\/boards"/);
   assert.match(js, /fetch\("\.\.\/api\/settings"/);
-  assert.match(js, /fetch\("https:\/\/api\.github\.com\/repos\/tolibear\/goalbuddy"/);
+  assert.match(js, /fetch\("https:\/\/api\.github\.com\/repos\/tolimarchuk\/goalbuddy"/);
   assert.match(js, /goalbuddy\.localBoardSettings\.v1/);
   assert.match(js, /document\.documentElement\.dataset\.theme/);
   assert.match(js, /rememberCurrentBoard/);

--- a/internal/cli/goal-maker.mjs
+++ b/internal/cli/goal-maker.mjs
@@ -955,12 +955,12 @@ Usage:
   ${canonicalCliName} plugin install [--source <marketplace-source>] [--codex-home <path>] [--json]
 
 Default source:
-  tolibear/goalbuddy
+  tolimarchuk/goalbuddy
 `);
 }
 
 function installPlugin({ quiet = false } = {}) {
-  const source = optionValue("--source") || "tolibear/goalbuddy";
+  const source = optionValue("--source") || "tolimarchuk/goalbuddy";
   const pluginSource = join(packageRoot, "plugins", pluginName);
   const pluginManifestPath = join(pluginSource, ".codex-plugin", "plugin.json");
   if (!existsSync(pluginManifestPath)) {

--- a/internal/site/DNS.md
+++ b/internal/site/DNS.md
@@ -2,7 +2,7 @@
 
 GitHub Pages is configured for:
 
-- Repository: `tolibear/goalbuddy`
+- Repository: `tolimarchuk/goalbuddy`
 - Pages build type: GitHub Actions workflow
 - Custom domain: `goalbuddy.dev`
 - Published artifact path: `internal/site`
@@ -32,7 +32,7 @@ Recommended `www` redirect support:
 
 ```text
 Type   Name  Content
-CNAME  www   tolibear.github.io
+CNAME  www   tolimarchuk.github.io
 ```
 
 After DNS resolves, re-check:

--- a/internal/site/index.html
+++ b/internal/site/index.html
@@ -47,10 +47,10 @@
           <a href="#workflow">Workflow</a>
           <a href="#local">Local files</a>
           <a href="#proof">Proof</a>
-          <a href="https://github.com/tolibear/goalbuddy">GitHub</a>
+          <a href="https://github.com/tolimarchuk/goalbuddy">GitHub</a>
         </nav>
         <div class="header-tools">
-          <a class="github-stars" href="https://github.com/tolibear/goalbuddy" aria-label="Open Goal Buddy on GitHub">
+          <a class="github-stars" href="https://github.com/tolimarchuk/goalbuddy" aria-label="Open Goal Buddy on GitHub">
             <i data-lucide="star"></i>
             <span data-github-stars>Stars</span>
           </a>
@@ -76,7 +76,7 @@
               <i data-lucide="terminal"></i>
               <span>npx goalbuddy</span>
             </a>
-            <a class="button button-secondary" href="https://github.com/tolibear/goalbuddy">
+            <a class="button button-secondary" href="https://github.com/tolimarchuk/goalbuddy">
               <i data-lucide="github"></i>
               View GitHub
             </a>
@@ -330,11 +330,11 @@
           <h2 id="star-history-title">Star History</h2>
           <p>Track GoalBuddy’s open source momentum over time.</p>
         </div>
-        <a href="https://www.star-history.com/?repos=tolibear%2Fgoalbuddy&type=date&legend=top-left">
+        <a href="https://www.star-history.com/?repos=tolimarchuk%2Fgoalbuddy&type=date&legend=top-left">
           <picture>
-            <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tolibear/goalbuddy&type=date&theme=dark&legend=top-left">
-            <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tolibear/goalbuddy&type=date&legend=top-left">
-            <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tolibear/goalbuddy&type=date&legend=top-left">
+            <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=tolimarchuk/goalbuddy&type=date&theme=dark&legend=top-left">
+            <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=tolimarchuk/goalbuddy&type=date&legend=top-left">
+            <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=tolimarchuk/goalbuddy&type=date&legend=top-left">
           </picture>
         </a>
       </section>
@@ -345,7 +345,7 @@
           <span>Goal Buddy</span>
         </a>
         <div class="footer-links">
-          <a class="repo-link" href="https://github.com/tolibear/goalbuddy">
+          <a class="repo-link" href="https://github.com/tolimarchuk/goalbuddy">
             <i data-lucide="github"></i>
             GitHub repo
           </a>

--- a/internal/site/script.js
+++ b/internal/site/script.js
@@ -102,7 +102,7 @@ async function loadGithubStars() {
   if (!starCount) return;
 
   try {
-    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+    const response = await fetch("https://api.github.com/repos/tolimarchuk/goalbuddy", {
       headers: { Accept: "application/vnd.github+json" },
     });
     if (!response.ok) throw new Error("GitHub API unavailable");

--- a/internal/test/goal-maker-cli.test.mjs
+++ b/internal/test/goal-maker-cli.test.mjs
@@ -967,7 +967,7 @@ test("reset removes only GoalBuddy-owned Codex runtime surfaces", () => {
       "enabled = true",
       "",
       "[marketplaces.goalbuddy]",
-      'source = "tolibear/goalbuddy"',
+      'source = "tolimarchuk/goalbuddy"',
       'source_type = "git"',
       "",
       "[marketplaces.goalbuddy.settings]",

--- a/internal/test/plugin-marketplace.test.mjs
+++ b/internal/test/plugin-marketplace.test.mjs
@@ -23,7 +23,7 @@ test("GoalBuddy plugin is exposed through a Codex marketplace manifest", () => {
 
 test("GoalBuddy plugin is exposed through a Claude marketplace manifest", () => {
   assert.equal(claudeMarketplace.name, "goalbuddy");
-  assert.equal(claudeMarketplace.owner.name, "tolibear");
+  assert.equal(claudeMarketplace.owner.name, "tolimarchuk");
   assert.equal(claudeMarketplace.plugins.length, 1);
 
   const [entry] = claudeMarketplace.plugins;
@@ -35,7 +35,7 @@ test("GoalBuddy plugin is exposed through a Claude marketplace manifest", () => 
 test("GoalBuddy plugin metadata tracks the package release", () => {
   assert.equal(plugin.name, pkg.name);
   assert.equal(plugin.version, pkg.version);
-  assert.equal(plugin.repository, "https://github.com/tolibear/goalbuddy");
+  assert.equal(plugin.repository, "https://github.com/tolimarchuk/goalbuddy");
   assert.equal(plugin.skills, "./skills/");
 });
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tolibear/goalbuddy.git"
+    "url": "git+https://github.com/tolimarchuk/goalbuddy.git"
   },
   "keywords": [
     "codex",
@@ -51,12 +51,12 @@
     "agent",
     "verification"
   ],
-  "author": "tolibear",
+  "author": "tolimarchuk",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/tolibear/goalbuddy/issues"
+    "url": "https://github.com/tolimarchuk/goalbuddy/issues"
   },
-  "homepage": "https://github.com/tolibear/goalbuddy#readme",
+  "homepage": "https://github.com/tolimarchuk/goalbuddy#readme",
   "engines": {
     "node": ">=18"
   },

--- a/plugins/goalbuddy/.claude-plugin/plugin.json
+++ b/plugins/goalbuddy/.claude-plugin/plugin.json
@@ -3,12 +3,12 @@
   "version": "0.4.3",
   "description": "Turn broad Codex and Claude Code work into pressured goal runs with oracles, local boards, receipts, and verification.",
   "author": {
-    "name": "tolibear",
+    "name": "tolimarchuk",
     "email": "support@tolibear.com",
-    "url": "https://github.com/tolibear"
+    "url": "https://github.com/tolimarchuk"
   },
   "homepage": "https://goalbuddy.dev",
-  "repository": "https://github.com/tolibear/goalbuddy",
+  "repository": "https://github.com/tolimarchuk/goalbuddy",
   "license": "MIT",
   "keywords": [
     "claude-code",

--- a/plugins/goalbuddy/.codex-plugin/plugin.json
+++ b/plugins/goalbuddy/.codex-plugin/plugin.json
@@ -3,12 +3,12 @@
   "version": "0.4.3",
   "description": "Turn broad Codex and Claude Code work into pressured goal runs with oracles, local boards, receipts, and verification.",
   "author": {
-    "name": "tolibear",
+    "name": "tolimarchuk",
     "email": "support@tolibear.com",
-    "url": "https://github.com/tolibear"
+    "url": "https://github.com/tolimarchuk"
   },
-  "homepage": "https://github.com/tolibear/goalbuddy#readme",
-  "repository": "https://github.com/tolibear/goalbuddy",
+  "homepage": "https://github.com/tolimarchuk/goalbuddy#readme",
+  "repository": "https://github.com/tolimarchuk/goalbuddy",
   "license": "MIT",
   "keywords": [
     "goalbuddy",
@@ -25,16 +25,16 @@
     "displayName": "GoalBuddy",
     "shortDescription": "Goal oracles, local boards, receipts, and proof loops for /goal",
     "longDescription": "GoalBuddy packages a structured goal workflow for broad, long-running, or ambiguous engineering work in Codex or Claude Code. It creates durable goal charters, goal oracles, task boards, optional depth-1 subgoals, local board surfaces, parallel-agent-ready handoffs, receipts, verification gates, and compatibility guidance for teams moving from goal-maker.",
-    "developerName": "tolibear",
+    "developerName": "tolimarchuk",
     "category": "Coding",
     "capabilities": [
       "Interactive",
       "Read",
       "Write"
     ],
-    "websiteURL": "https://github.com/tolibear/goalbuddy",
-    "privacyPolicyURL": "https://github.com/tolibear/goalbuddy#privacy",
-    "termsOfServiceURL": "https://github.com/tolibear/goalbuddy#license",
+    "websiteURL": "https://github.com/tolimarchuk/goalbuddy",
+    "privacyPolicyURL": "https://github.com/tolimarchuk/goalbuddy#privacy",
+    "termsOfServiceURL": "https://github.com/tolimarchuk/goalbuddy#license",
     "defaultPrompt": [
       "$goal-prep prepare a GoalBuddy board for this goal"
     ],

--- a/plugins/goalbuddy/README.md
+++ b/plugins/goalbuddy/README.md
@@ -66,4 +66,4 @@ node internal/cli/goal-maker.mjs board docs/goals/<slug> --once --json
 
 ## Release Notes
 
-The plugin is prepared for the `tolibear/goalbuddy` repo and `goalbuddy` npm package. Keep `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` aligned with `package.json` before publishing a new package release.
+The plugin is prepared for the `tolimarchuk/goalbuddy` repo and `goalbuddy` npm package. Keep `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` aligned with `package.json` before publishing a new package release.

--- a/plugins/goalbuddy/skills/goal-prep/surfaces/local-goal-board/scripts/lib/goal-board.mjs
+++ b/plugins/goalbuddy/skills/goal-prep/surfaces/local-goal-board/scripts/lib/goal-board.mjs
@@ -783,7 +783,7 @@ function boardHtml() {
       </nav>
     </div>
     <div class="header-tools">
-      <a class="github-stars" href="https://github.com/tolibear/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
+      <a class="github-stars" href="https://github.com/tolimarchuk/goalbuddy" target="_blank" rel="noreferrer" aria-label="Open GoalBuddy on GitHub">
         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 2.8 2.84 5.76 6.36.92-4.6 4.48 1.08 6.34L12 17.32 6.32 20.3l1.08-6.34-4.6-4.48 6.36-.92L12 2.8Z"></path></svg>
         <span id="github-stars">Stars</span>
       </a>
@@ -2069,7 +2069,7 @@ function formatStars(count) {
 async function loadGithubStars() {
   if (!githubStarsEl) return;
   try {
-    const response = await fetch("https://api.github.com/repos/tolibear/goalbuddy", {
+    const response = await fetch("https://api.github.com/repos/tolimarchuk/goalbuddy", {
       headers: { Accept: "application/vnd.github+json" },
     });
     if (!response.ok) throw new Error("GitHub API unavailable");

--- a/plugins/goalbuddy/skills/goal-prep/surfaces/local-goal-board/test/local-goal-board.test.mjs
+++ b/plugins/goalbuddy/skills/goal-prep/surfaces/local-goal-board/test/local-goal-board.test.mjs
@@ -336,7 +336,7 @@ test("writes a minimal GoalBuddy web app into the goal directory", () => {
   assert.match(js, /new EventSource\("\.\/events"\)/);
   assert.match(js, /fetch\("\.\.\/api\/boards"/);
   assert.match(js, /fetch\("\.\.\/api\/settings"/);
-  assert.match(js, /fetch\("https:\/\/api\.github\.com\/repos\/tolibear\/goalbuddy"/);
+  assert.match(js, /fetch\("https:\/\/api\.github\.com\/repos\/tolimarchuk\/goalbuddy"/);
   assert.match(js, /goalbuddy\.localBoardSettings\.v1/);
   assert.match(js, /document\.documentElement\.dataset\.theme/);
   assert.match(js, /rememberCurrentBoard/);


### PR DESCRIPTION
GoalBuddy still pointed installers, package metadata, plugin manifests, documentation, and public UI links at the former `tolibear` GitHub namespace after the account moved to `tolimarchuk`. This updates active repository references and the default Codex marketplace source while preserving the `goalbuddy` npm name, support email, social handle, license attribution, and historical changelog links.

Validation:

- `npm run check` (133 tests passed)
- isolated Codex plugin installer test (1 test passed)
- generated plugin skill tree synchronized with the canonical skill tree
